### PR TITLE
Less open vr

### DIFF
--- a/src/main/java/org/terasology/basicrendering/rendering/dag/nodes/DeferredPointLightsNode.java
+++ b/src/main/java/org/terasology/basicrendering/rendering/dag/nodes/DeferredPointLightsNode.java
@@ -1,11 +1,11 @@
 /*
- * Copyright 2017 MovingBlocks
+ * Copyright 2020 MovingBlocks
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
  * You may obtain a copy of the License at
  *
- *      http://www.apache.org/licenses/LICENSE-2.0
+ *     https://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing, software
  * distributed under the License is distributed on an "AS IS" BASIS,
@@ -18,10 +18,10 @@ package org.terasology.corerendering.rendering.dag.nodes;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.util.glu.Sphere;
 import org.terasology.assets.ResourceUrn;
-import org.terasology.corerendering.rendering.CoreenderingModule;
 import org.terasology.config.Config;
 import org.terasology.config.RenderingConfig;
 import org.terasology.context.Context;
+import org.terasology.corerendering.rendering.CoreRenderingModule;
 import org.terasology.engine.module.rendering.RenderingModuleRegistry;
 import org.terasology.entitySystem.entity.EntityManager;
 import org.terasology.entitySystem.entity.EntityRef;
@@ -35,8 +35,8 @@ import org.terasology.rendering.assets.material.Material;
 import org.terasology.rendering.assets.shader.ShaderProgramFeature;
 import org.terasology.rendering.cameras.Camera;
 import org.terasology.rendering.cameras.SubmersibleCamera;
-import org.terasology.rendering.dag.dependencyConnections.BufferPairConnection;
 import org.terasology.rendering.dag.AbstractNode;
+import org.terasology.rendering.dag.dependencyConnections.BufferPairConnection;
 import org.terasology.rendering.dag.stateChanges.BindFbo;
 import org.terasology.rendering.dag.stateChanges.DisableDepthTest;
 import org.terasology.rendering.dag.stateChanges.EnableBlending;

--- a/src/main/java/org/terasology/basicrendering/rendering/dag/nodes/OutputToHMDNode.java
+++ b/src/main/java/org/terasology/basicrendering/rendering/dag/nodes/OutputToHMDNode.java
@@ -15,7 +15,7 @@
  */
 package org.terasology.corerendering.rendering.dag.nodes;
 
-import jopenvr.JOpenVRLibrary;
+//import jopenvr.JOpenVRLibrary;
 import org.lwjgl.opengl.GL11;
 import org.terasology.assets.ResourceUrn;
 import org.terasology.config.Config;
@@ -69,7 +69,7 @@ public class OutputToHMDNode extends ConditionDependentNode {
             leftEyeFbo = requiresFbo(new FboConfig(LEFT_EYE_FBO_URI, FULL_SCALE, FBO.Type.DEFAULT).useDepthBuffer(), displayResolutionDependentFBOs);
             rightEyeFbo = requiresFbo(new FboConfig(RIGHT_EYE_FBO_URI, FULL_SCALE, FBO.Type.DEFAULT).useDepthBuffer(), displayResolutionDependentFBOs);
             finalFbo = displayResolutionDependentFBOs.get(FINAL_BUFFER);
-
+/* TODO: Re-enable when we try to get OpenVR working again. Disabled due to a natives issue with
             vrProvider.texType[0].handle = leftEyeFbo.getColorBufferTextureId();
             vrProvider.texType[0].eColorSpace = JOpenVRLibrary.EColorSpace.EColorSpace_ColorSpace_Gamma;
             vrProvider.texType[0].eType = JOpenVRLibrary.EGraphicsAPIConvention.EGraphicsAPIConvention_API_OpenGL;
@@ -78,7 +78,7 @@ public class OutputToHMDNode extends ConditionDependentNode {
             vrProvider.texType[1].eColorSpace = JOpenVRLibrary.EColorSpace.EColorSpace_ColorSpace_Gamma;
             vrProvider.texType[1].eType = JOpenVRLibrary.EGraphicsAPIConvention.EGraphicsAPIConvention_API_OpenGL;
             vrProvider.texType[1].write();
-
+*/
             addDesiredStateChange(new EnableMaterial(DEFAULT_TEXTURED_MATERIAL_URN));
         }
     }


### PR DESCRIPTION
Would otherwise break in standalone module build mode. Essentially https://github.com/MovingBlocks/Terasology/pull/3897 but in moduleland - the big DAG PR came before I did the tweak in the engine with (some?) associated code now moved here.

Includes #7 by @keturn (nice catch!) but does _not_ include tweaking package/pathing to finish out the rename to CoreRendering