### PR TITLE
fix reversed lightshafts

### DIFF
--- a/src/main/java/org/terasology/corerendering/rendering/dag/nodes/BackdropNode.java
+++ b/src/main/java/org/terasology/corerendering/rendering/dag/nodes/BackdropNode.java
@@ -15,14 +15,14 @@
  */
 package org.terasology.corerendering.rendering.dag.nodes;
 
+import org.joml.Vector3f;
+import org.joml.Vector4f;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.util.glu.Sphere;
 import org.terasology.assets.ResourceUrn;
 import org.terasology.config.Config;
 import org.terasology.config.RenderingDebugConfig;
 import org.terasology.context.Context;
-import org.terasology.math.geom.Vector3f;
-import org.terasology.math.geom.Vector4f;
 import org.terasology.monitoring.PerformanceMonitor;
 import org.terasology.naming.Name;
 import org.terasology.rendering.assets.material.Material;

--- a/src/main/java/org/terasology/corerendering/rendering/dag/nodes/BackdropReflectionNode.java
+++ b/src/main/java/org/terasology/corerendering/rendering/dag/nodes/BackdropReflectionNode.java
@@ -15,12 +15,12 @@
  */
 package org.terasology.corerendering.rendering.dag.nodes;
 
+import org.joml.Vector3f;
 import org.lwjgl.opengl.GL11;
 import org.lwjgl.util.glu.Sphere;
 import org.terasology.assets.ResourceUrn;
 import org.terasology.context.Context;
 import org.terasology.engine.SimpleUri;
-import org.terasology.math.geom.Vector3f;
 import org.terasology.monitoring.PerformanceMonitor;
 import org.terasology.naming.Name;
 import org.terasology.rendering.assets.material.Material;

--- a/src/main/java/org/terasology/corerendering/rendering/dag/nodes/DeferredMainLightNode.java
+++ b/src/main/java/org/terasology/corerendering/rendering/dag/nodes/DeferredMainLightNode.java
@@ -164,7 +164,7 @@ public class DeferredMainLightNode extends AbstractNode {
         // Specific Shader Parameters
 
         cameraPosition = activeCamera.getPosition();
-        mainLightInViewSpace = JomlUtil.from(backdropProvider.getSunDirection(true));
+        mainLightInViewSpace = backdropProvider.getSunDirection(true);
         activeCamera.getViewMatrix().transformPosition(mainLightInViewSpace);
 
         // TODO: This is necessary right now because activateFeature removes all material parameters.

--- a/src/main/java/org/terasology/corerendering/rendering/dag/nodes/LightShaftsNode.java
+++ b/src/main/java/org/terasology/corerendering/rendering/dag/nodes/LightShaftsNode.java
@@ -15,7 +15,6 @@
  */
 package org.terasology.corerendering.rendering.dag.nodes;
 
-import org.joml.Matrix4f;
 import org.joml.Vector3f;
 import org.joml.Vector4f;
 import org.terasology.assets.ResourceUrn;
@@ -23,7 +22,6 @@ import org.terasology.config.Config;
 import org.terasology.config.RenderingConfig;
 import org.terasology.context.Context;
 import org.terasology.engine.SimpleUri;
-import org.terasology.math.JomlUtil;
 import org.terasology.monitoring.PerformanceMonitor;
 import org.terasology.naming.Name;
 import org.terasology.rendering.assets.material.Material;

--- a/src/main/java/org/terasology/corerendering/rendering/dag/nodes/LightShaftsNode.java
+++ b/src/main/java/org/terasology/corerendering/rendering/dag/nodes/LightShaftsNode.java
@@ -145,10 +145,10 @@ public class LightShaftsNode extends ConditionDependentNode {
         // This is a temporary solution to sun causing light shafts even at night.
 
         if (days < 0.25f || days > 0.75f) {
-            sunDirection = JomlUtil.from(backdropProvider.getSunDirection(true));
+            sunDirection = backdropProvider.getSunDirection(true);
             exposure = exposureNight;
         } else {
-            sunDirection = JomlUtil.from(backdropProvider.getSunDirection(false));
+            sunDirection = backdropProvider.getSunDirection(false);
             exposure = exposureDay;
         }
 
@@ -159,7 +159,7 @@ public class LightShaftsNode extends ConditionDependentNode {
         lightShaftsMaterial.setFloat("weight", weight, true);
         lightShaftsMaterial.setFloat("decay", decay, true);
 
-        sunPositionWorldSpace4.set(sunDirection.x * 10000.0f, sunDirection.y * 10000.0f, sunDirection.z * 10000.0f, 1.0f);
+        sunPositionWorldSpace4.set(-sunDirection.x * 10000.0f, -sunDirection.y * 10000.0f, -sunDirection.z * 10000.0f, 1.0f);
         sunPositionScreenSpace.set(sunPositionWorldSpace4);
         activeCamera.getViewProjectionMatrix().transform(sunPositionScreenSpace);
 

--- a/src/main/java/org/terasology/corerendering/rendering/dag/nodes/RefractiveReflectiveBlocksNode.java
+++ b/src/main/java/org/terasology/corerendering/rendering/dag/nodes/RefractiveReflectiveBlocksNode.java
@@ -16,12 +16,12 @@
 package org.terasology.corerendering.rendering.dag.nodes;
 
 import org.joml.Vector3f;
+import org.joml.Vector3i;
 import org.terasology.assets.ResourceUrn;
 import org.terasology.config.Config;
 import org.terasology.config.RenderingConfig;
 import org.terasology.context.Context;
 import org.terasology.engine.SimpleUri;
-import org.terasology.math.JomlUtil;
 import org.terasology.monitoring.PerformanceMonitor;
 import org.terasology.naming.Name;
 import org.terasology.rendering.assets.material.Material;
@@ -239,7 +239,7 @@ public class RefractiveReflectiveBlocksNode extends AbstractNode implements Prop
 
         // Common Shader Parameters
 
-        sunDirection = JomlUtil.from(backdropProvider.getSunDirection(false));
+        sunDirection = backdropProvider.getSunDirection(false);
 
         chunkMaterial.setFloat("daylight", backdropProvider.getDaylight(), true);
         chunkMaterial.setFloat("swimming", activeCamera.isUnderWater() ? 1.0f : 0.0f, true);
@@ -292,7 +292,7 @@ public class RefractiveReflectiveBlocksNode extends AbstractNode implements Prop
 
             if (chunk.hasMesh()) {
                 final ChunkMesh chunkMesh = chunk.getMesh();
-                final Vector3f chunkPosition = new Vector3f(JomlUtil.from(chunk.getPosition()));
+                final Vector3f chunkPosition = new Vector3f(chunk.getPosition(new Vector3i()));
 
                 chunkMesh.updateMaterial(chunkMaterial, chunkPosition, chunk.isAnimated());
                 numberOfRenderedTriangles += chunkMesh.render(REFRACTIVE, chunkPosition, cameraPosition);


### PR DESCRIPTION
I also migrated the backdrop provider in the process: https://github.com/MovingBlocks/Terasology/pull/4110 .

The light shafts in the current upstream branch is flipped. Shouldn't be too difficult to verify. try with the default upstream then this branch with the engine changes in PR https://github.com/MovingBlocks/Terasology/pull/4110. The light shafts should be pointing outwards from the sun where they are flipped in the current working version of the engine. 

![image](https://user-images.githubusercontent.com/854359/89094286-34492800-d377-11ea-9ca8-eaf526d5a4d0.png)
