### PR TITLE
Update for engine PR #4600

### DIFF
--- a/src/main/java/org/terasology/corerendering/rendering/dag/nodes/AlphaRejectBlocksNode.java
+++ b/src/main/java/org/terasology/corerendering/rendering/dag/nodes/AlphaRejectBlocksNode.java
@@ -196,7 +196,7 @@ public class AlphaRejectBlocksNode extends AbstractNode implements WireframeCapa
 
             if (chunk.hasMesh()) {
                 final ChunkMesh chunkMesh = chunk.getMesh();
-                final Vector3f chunkPosition = new Vector3f(chunk.getPosition(new Vector3i()));
+                final Vector3f chunkPosition = chunk.getRenderPosition();
 
                 chunkMesh.updateMaterial(chunkMaterial, chunkPosition, chunk.isAnimated());
                 numberOfRenderedTriangles += chunkMesh.render(ALPHA_REJECT, chunkPosition, cameraPosition);

--- a/src/main/java/org/terasology/corerendering/rendering/dag/nodes/OpaqueBlocksNode.java
+++ b/src/main/java/org/terasology/corerendering/rendering/dag/nodes/OpaqueBlocksNode.java
@@ -11,8 +11,6 @@ import org.terasology.engine.config.RenderingConfig;
 import org.terasology.engine.config.RenderingDebugConfig;
 import org.terasology.engine.context.Context;
 import org.terasology.engine.monitoring.PerformanceMonitor;
-import org.terasology.naming.Name;
-import org.terasology.nui.properties.Range;
 import org.terasology.engine.rendering.AABBRenderer;
 import org.terasology.engine.rendering.assets.material.Material;
 import org.terasology.engine.rendering.cameras.SubmersibleCamera;
@@ -33,6 +31,8 @@ import org.terasology.engine.rendering.world.WorldRenderer;
 import org.terasology.engine.world.WorldProvider;
 import org.terasology.engine.world.chunks.Chunks;
 import org.terasology.engine.world.chunks.RenderableChunk;
+import org.terasology.naming.Name;
+import org.terasology.nui.properties.Range;
 
 import java.beans.PropertyChangeEvent;
 import java.beans.PropertyChangeListener;
@@ -187,7 +187,7 @@ public class OpaqueBlocksNode extends AbstractNode implements WireframeCapable, 
 
             if (chunk.hasMesh()) {
                 final ChunkMesh chunkMesh = chunk.getMesh();
-                final Vector3f chunkPosition = new Vector3f(chunk.getPosition());
+                final Vector3f chunkPosition = chunk.getRenderPosition();
 
                 chunkMesh.updateMaterial(chunkMaterial, chunkPosition, chunk.isAnimated());
                 numberOfRenderedTriangles += chunkMesh.render(OPAQUE, chunkPosition, cameraPosition);
@@ -212,9 +212,9 @@ public class OpaqueBlocksNode extends AbstractNode implements WireframeCapable, 
 
         // chunkPositionRelativeToCamera = chunkCoordinates * chunkDimensions - cameraCoordinate
         final Vector3f chunkPositionRelativeToCamera =
-                new Vector3f(chunkPosition.x * Chunks.SIZE_X - cameraPosition.x(),
-                        chunkPosition.y * Chunks.SIZE_Y - cameraPosition.y(),
-                        chunkPosition.z * Chunks.SIZE_Z - cameraPosition.z());
+                new Vector3f(chunkPosition.x - cameraPosition.x(),
+                        chunkPosition.y - cameraPosition.y(),
+                        chunkPosition.z - cameraPosition.z());
         GL11.glTranslatef(chunkPositionRelativeToCamera.x, chunkPositionRelativeToCamera.y, chunkPositionRelativeToCamera.z);
 
         new AABBRenderer(chunk.getAABB()).renderLocally(1f);

--- a/src/main/java/org/terasology/corerendering/rendering/dag/nodes/RefractiveReflectiveBlocksNode.java
+++ b/src/main/java/org/terasology/corerendering/rendering/dag/nodes/RefractiveReflectiveBlocksNode.java
@@ -292,7 +292,7 @@ public class RefractiveReflectiveBlocksNode extends AbstractNode implements Prop
 
             if (chunk.hasMesh()) {
                 final ChunkMesh chunkMesh = chunk.getMesh();
-                final Vector3f chunkPosition = new Vector3f(chunk.getPosition(new Vector3i()));
+                final Vector3f chunkPosition = chunk.getRenderPosition();
 
                 chunkMesh.updateMaterial(chunkMaterial, chunkPosition, chunk.isAnimated());
                 numberOfRenderedTriangles += chunkMesh.render(REFRACTIVE, chunkPosition, cameraPosition);

--- a/src/main/java/org/terasology/corerendering/rendering/dag/nodes/ShadowMapNode.java
+++ b/src/main/java/org/terasology/corerendering/rendering/dag/nodes/ShadowMapNode.java
@@ -173,10 +173,7 @@ public class ShadowMapNode extends ConditionDependentNode implements PropertyCha
             while (renderQueues.chunksOpaqueShadow.size() > 0) {
                 RenderableChunk chunk = renderQueues.chunksOpaqueShadow.poll();
                 if (chunk.hasMesh()) {
-                    model.setTranslation(
-                            chunk.getPosition().x() * Chunks.SIZE_X - cameraPosition.x(),
-                            chunk.getPosition().y() * Chunks.SIZE_Y - cameraPosition.y(),
-                            chunk.getPosition().z() * Chunks.SIZE_Z - cameraPosition.z());
+                    model.setTranslation(chunk.getRenderPosition().sub(cameraPosition));
                     modelViewMatrix.set(shadowMapCamera.getViewMatrix()).mul(model);
                     shadowMapMaterial.setMatrix4("modelView", modelViewMatrix, true);
                     numberOfRenderedTriangles += chunk.getMesh().render(OPAQUE);

--- a/src/main/java/org/terasology/corerendering/rendering/dag/nodes/WorldReflectionNode.java
+++ b/src/main/java/org/terasology/corerendering/rendering/dag/nodes/WorldReflectionNode.java
@@ -199,7 +199,7 @@ public class WorldReflectionNode extends ConditionDependentNode {
 
             if (chunk.hasMesh()) {
                 final ChunkMesh chunkMesh = chunk.getMesh();
-                final Vector3f chunkPosition = new Vector3f(chunk.getPosition(new Vector3i()));
+                final Vector3f chunkPosition = chunk.getRenderPosition();
 
                 chunkMesh.updateMaterial(chunkMaterial, chunkPosition, chunk.isAnimated());
                 numberOfRenderedTriangles += chunkMesh.render(OPAQUE, chunkPosition, cameraPosition);


### PR DESCRIPTION
Make use of the new `RenderableChunk` interface that was changed in https://github.com/MovingBlocks/Terasology/pull/4600.