### PR TITLE
chore: migrate backdrop node with changes to skysphere

### DIFF
--- a/src/main/java/org/terasology/corerendering/rendering/dag/nodes/BackdropNode.java
+++ b/src/main/java/org/terasology/corerendering/rendering/dag/nodes/BackdropNode.java
@@ -1,18 +1,5 @@
-/*
- * Copyright 2017 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.corerendering.rendering.dag.nodes;
 
 import org.joml.Vector3f;
@@ -118,7 +105,7 @@ public class BackdropNode extends AbstractNode implements WireframeCapable {
         SubmersibleCamera activeCamera = worldRenderer.getActiveCamera();
         addDesiredStateChange(new LookThroughNormalized(activeCamera));
 
-        initSkysphere(activeCamera.getzFar() < RADIUS ? activeCamera.getzFar() : RADIUS);
+        sphereMesh.reload(builder.setRadius(activeCamera.getzFar() < RADIUS ? activeCamera.getzFar() : RADIUS).build());
 
         RenderingDebugConfig renderingDebugConfig = context.get(Config.class).getRendering().getDebug();
         new WireframeTrigger(renderingDebugConfig, this);
@@ -192,10 +179,6 @@ public class BackdropNode extends AbstractNode implements WireframeCapable {
         sphereMesh.render();
 
         PerformanceMonitor.endActivity();
-    }
-
-    private void initSkysphere(float sphereRadius) {
-        sphereMesh.reload(builder.setRadius(sphereRadius).build());
     }
 
     static Vector3f getAllWeatherZenith(float thetaSunAngle, float turbidity) {

--- a/src/main/java/org/terasology/corerendering/rendering/dag/nodes/BackdropNode.java
+++ b/src/main/java/org/terasology/corerendering/rendering/dag/nodes/BackdropNode.java
@@ -94,9 +94,6 @@ public class BackdropNode extends AbstractNode implements WireframeCapable {
                         .setRadius(RADIUS)
                         .setTextured(true).build(),
                 Mesh.class);
-
-        // addOutputFboConnection(1);
-        // addOutputBufferPairConnection(1);
     }
 
     @Override

--- a/src/main/java/org/terasology/corerendering/rendering/dag/nodes/BackdropNode.java
+++ b/src/main/java/org/terasology/corerendering/rendering/dag/nodes/BackdropNode.java
@@ -17,12 +17,14 @@ package org.terasology.corerendering.rendering.dag.nodes;
 
 import org.joml.Vector3f;
 import org.joml.Vector4f;
-import org.lwjgl.opengl.GL11;
-import org.terasology.engine.rendering.primitives.Sphere;
+import org.terasology.engine.rendering.assets.mesh.Mesh;
+import org.terasology.engine.rendering.assets.mesh.SphereBuilder;
+import org.terasology.engine.rendering.cameras.Camera;
 import org.terasology.engine.config.Config;
 import org.terasology.engine.config.RenderingDebugConfig;
 import org.terasology.engine.context.Context;
 import org.terasology.engine.monitoring.PerformanceMonitor;
+import org.terasology.engine.utilities.Assets;
 import org.terasology.gestalt.assets.ResourceUrn;
 import org.terasology.gestalt.naming.Name;
 import org.terasology.nui.properties.Range;
@@ -46,10 +48,6 @@ import org.terasology.engine.rendering.opengl.FBO;
 import org.terasology.engine.rendering.world.WorldRenderer;
 
 import static org.lwjgl.opengl.GL11.GL_FRONT;
-import static org.lwjgl.opengl.GL11.glCallList;
-import static org.lwjgl.opengl.GL11.glEndList;
-import static org.lwjgl.opengl.GL11.glGenLists;
-import static org.lwjgl.opengl.GL11.glNewList;
 
 /**
  * Renders the backdrop.
@@ -69,7 +67,6 @@ public class BackdropNode extends AbstractNode implements WireframeCapable {
     private WorldRenderer worldRenderer;
     private BackdropProvider backdropProvider;
 
-    private int skySphere = -1;
     private SetWireframe wireframeStateChange;
 
     private Material skyMaterial;
@@ -92,6 +89,9 @@ public class BackdropNode extends AbstractNode implements WireframeCapable {
     @SuppressWarnings("FieldCanBeLocal")
     private float turbidity;
 
+    private final Mesh sphereMesh;
+    SphereBuilder builder = new SphereBuilder();
+
     public BackdropNode(String nodeUri, Name providingModule, Context context) {
         super(nodeUri, providingModule, context);
 
@@ -100,6 +100,13 @@ public class BackdropNode extends AbstractNode implements WireframeCapable {
         wireframeStateChange = new SetWireframe(true);
 
         skyMaterial = getMaterial(SKY_MATERIAL_URN);
+
+        sphereMesh = Assets.generateAsset(builder
+                        .setVerticalCuts(SLICES)
+                        .setHorizontalCuts(STACKS)
+                        .setRadius(RADIUS)
+                        .setTextured(true).build(),
+                Mesh.class);
 
         // addOutputFboConnection(1);
         // addOutputBufferPairConnection(1);
@@ -177,22 +184,18 @@ public class BackdropNode extends AbstractNode implements WireframeCapable {
         skyMaterial.setFloat("colorExp", backdropProvider.getColorExp(), true);
         skyMaterial.setFloat4("skySettings", sunExponent, moonExponent, skyDaylightBrightness, skyNightBrightness, true);
 
-        // Actual Node Processing
+        Camera camera = worldRenderer.getActiveCamera();
+        skyMaterial.setMatrix4("projectionMatrix", camera.getProjectionMatrix());
+        skyMaterial.setMatrix4("modelViewMatrix", camera.getNormViewMatrix());
 
-        glCallList(skySphere); // Draws the skysphere
+        // Actual Node Processing
+        sphereMesh.render();
 
         PerformanceMonitor.endActivity();
     }
 
     private void initSkysphere(float sphereRadius) {
-        Sphere sphere = new Sphere();
-        sphere.setTextureFlag(true);
-
-        skySphere = glGenLists(1);
-
-        glNewList(skySphere, GL11.GL_COMPILE);
-        sphere.draw(sphereRadius, SLICES, STACKS);
-        glEndList();
+        sphereMesh.reload(builder.setRadius(sphereRadius).build());
     }
 
     static Vector3f getAllWeatherZenith(float thetaSunAngle, float turbidity) {

--- a/src/main/java/org/terasology/corerendering/rendering/dag/nodes/BackdropReflectionNode.java
+++ b/src/main/java/org/terasology/corerendering/rendering/dag/nodes/BackdropReflectionNode.java
@@ -1,35 +1,16 @@
-/*
- * Copyright 2017 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.corerendering.rendering.dag.nodes;
 
 import org.joml.Vector3f;
-import org.lwjgl.opengl.GL11;
+import org.terasology.engine.context.Context;
 import org.terasology.engine.core.SimpleUri;
+import org.terasology.engine.monitoring.PerformanceMonitor;
+import org.terasology.engine.rendering.assets.material.Material;
 import org.terasology.engine.rendering.assets.mesh.Mesh;
 import org.terasology.engine.rendering.assets.mesh.SphereBuilder;
-import org.terasology.engine.rendering.cameras.Camera;
-import org.terasology.engine.rendering.primitives.Sphere;
-import org.terasology.engine.utilities.Assets;
-import org.terasology.gestalt.assets.ResourceUrn;
-import org.terasology.engine.context.Context;
-import org.terasology.engine.monitoring.PerformanceMonitor;
-import org.terasology.gestalt.naming.Name;
-import org.terasology.nui.properties.Range;
-import org.terasology.engine.rendering.assets.material.Material;
 import org.terasology.engine.rendering.backdrop.BackdropProvider;
+import org.terasology.engine.rendering.cameras.Camera;
 import org.terasology.engine.rendering.cameras.SubmersibleCamera;
 import org.terasology.engine.rendering.dag.AbstractNode;
 import org.terasology.engine.rendering.dag.stateChanges.BindFbo;
@@ -42,10 +23,11 @@ import org.terasology.engine.rendering.dag.stateChanges.SetInputTexture2D;
 import org.terasology.engine.rendering.dag.stateChanges.SetViewportToSizeOf;
 import org.terasology.engine.rendering.opengl.FBO;
 import org.terasology.engine.rendering.world.WorldRenderer;
+import org.terasology.engine.utilities.Assets;
+import org.terasology.gestalt.assets.ResourceUrn;
+import org.terasology.gestalt.naming.Name;
+import org.terasology.nui.properties.Range;
 
-import static org.lwjgl.opengl.GL11.glEndList;
-import static org.lwjgl.opengl.GL11.glGenLists;
-import static org.lwjgl.opengl.GL11.glNewList;
 import static org.terasology.corerendering.rendering.dag.nodes.BackdropNode.getAllWeatherZenith;
 
 /**
@@ -68,9 +50,6 @@ public class BackdropReflectionNode extends AbstractNode {
     private static final int STACKS = 128;
 
     private BackdropProvider backdropProvider;
-
-    private int skySphere = -1;
-
     private Material skyMaterial;
 
     @SuppressWarnings("FieldCanBeLocal")
@@ -122,7 +101,6 @@ public class BackdropReflectionNode extends AbstractNode {
         SubmersibleCamera activeCamera = renderer.getActiveCamera();
         addDesiredStateChange(new ReflectedCamera(activeCamera));
         addDesiredStateChange(new LookThroughNormalized(activeCamera));
-//        initSkysphere();
 
         FBO reflectedFbo = getInputFboData(1);
         addDesiredStateChange(new BindFbo(reflectedFbo));
@@ -172,19 +150,7 @@ public class BackdropReflectionNode extends AbstractNode {
         // Actual Node Processing
 
         sphereMesh.render();
-//        glCallList(skySphere); // Draws the skysphere
 
         PerformanceMonitor.endActivity();
-    }
-
-    private void initSkysphere() {
-        Sphere sphere = new Sphere();
-        sphere.setTextureFlag(true);
-
-        skySphere = glGenLists(1);
-
-        glNewList(skySphere, GL11.GL_COMPILE);
-        sphere.draw(RADIUS, SLICES, STACKS);
-        glEndList();
     }
 }

--- a/src/main/java/org/terasology/corerendering/rendering/dag/nodes/BackdropReflectionNode.java
+++ b/src/main/java/org/terasology/corerendering/rendering/dag/nodes/BackdropReflectionNode.java
@@ -18,7 +18,11 @@ package org.terasology.corerendering.rendering.dag.nodes;
 import org.joml.Vector3f;
 import org.lwjgl.opengl.GL11;
 import org.terasology.engine.core.SimpleUri;
+import org.terasology.engine.rendering.assets.mesh.Mesh;
+import org.terasology.engine.rendering.assets.mesh.SphereBuilder;
+import org.terasology.engine.rendering.cameras.Camera;
 import org.terasology.engine.rendering.primitives.Sphere;
+import org.terasology.engine.utilities.Assets;
 import org.terasology.gestalt.assets.ResourceUrn;
 import org.terasology.engine.context.Context;
 import org.terasology.engine.monitoring.PerformanceMonitor;
@@ -39,7 +43,6 @@ import org.terasology.engine.rendering.dag.stateChanges.SetViewportToSizeOf;
 import org.terasology.engine.rendering.opengl.FBO;
 import org.terasology.engine.rendering.world.WorldRenderer;
 
-import static org.lwjgl.opengl.GL11.glCallList;
 import static org.lwjgl.opengl.GL11.glEndList;
 import static org.lwjgl.opengl.GL11.glGenLists;
 import static org.lwjgl.opengl.GL11.glNewList;
@@ -88,6 +91,9 @@ public class BackdropReflectionNode extends AbstractNode {
     @SuppressWarnings("FieldCanBeLocal")
     private float turbidity;
 
+    private final Mesh sphereMesh;
+    private final WorldRenderer renderer;
+
     /**
      * Internally requires the "engine:sceneReflected" buffer, stored in the (display) resolution-dependent FBO manager.
      * This is a default, half-scale buffer inclusive of a depth buffer FBO. See FboConfig and ScalingFactors for details
@@ -98,16 +104,25 @@ public class BackdropReflectionNode extends AbstractNode {
     public BackdropReflectionNode(String nodeUri, Name providingModule, Context context) {
         super(nodeUri, providingModule, context);
         addOutputFboConnection(1);
+        renderer = context.get(WorldRenderer.class);
+
+        SphereBuilder builder = new SphereBuilder();
+        sphereMesh = Assets.generateAsset(builder
+                        .setVerticalCuts(STACKS)
+                        .setHorizontalCuts(SLICES)
+                        .setRadius(RADIUS)
+                        .setTextured(true).build(),
+                Mesh.class);
     }
 
     @Override
     public void setDependencies(Context context) {
         backdropProvider = context.get(BackdropProvider.class);
 
-        SubmersibleCamera activeCamera = context.get(WorldRenderer.class).getActiveCamera();
+        SubmersibleCamera activeCamera = renderer.getActiveCamera();
         addDesiredStateChange(new ReflectedCamera(activeCamera));
         addDesiredStateChange(new LookThroughNormalized(activeCamera));
-        initSkysphere();
+//        initSkysphere();
 
         FBO reflectedFbo = getInputFboData(1);
         addDesiredStateChange(new BindFbo(reflectedFbo));
@@ -150,9 +165,14 @@ public class BackdropReflectionNode extends AbstractNode {
         skyMaterial.setFloat("colorExp", backdropProvider.getColorExp(), true);
         skyMaterial.setFloat4("skySettings", sunExponent, moonExponent, skyDaylightBrightness, skyNightBrightness, true);
 
+        Camera camera = renderer.getActiveCamera();
+        skyMaterial.setMatrix4("projectionMatrix", camera.getProjectionMatrix());
+        skyMaterial.setMatrix4("modelViewMatrix", camera.getNormViewMatrix());
+
         // Actual Node Processing
 
-        glCallList(skySphere); // Draws the skysphere
+        sphereMesh.render();
+//        glCallList(skySphere); // Draws the skysphere
 
         PerformanceMonitor.endActivity();
     }


### PR DESCRIPTION
this gets rid of the glcalllist for skysphere. 

PR: https://github.com/MovingBlocks/Terasology/pull/4729