### PR TITLE
refactor: remove usage of LookThrough for SimpleBlendMaterialsNode

### DIFF
--- a/src/main/java/org/terasology/corerendering/rendering/dag/nodes/SimpleBlendMaterialsNode.java
+++ b/src/main/java/org/terasology/corerendering/rendering/dag/nodes/SimpleBlendMaterialsNode.java
@@ -1,34 +1,18 @@
-/*
- * Copyright 2017 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.corerendering.rendering.dag.nodes;
 
 import org.terasology.engine.context.Context;
 import org.terasology.engine.core.ComponentSystemManager;
 import org.terasology.engine.entitySystem.systems.RenderSystem;
 import org.terasology.engine.monitoring.PerformanceMonitor;
-import org.terasology.gestalt.naming.Name;
-import org.terasology.engine.rendering.cameras.Camera;
 import org.terasology.engine.rendering.dag.AbstractNode;
 import org.terasology.engine.rendering.dag.dependencyConnections.BufferPairConnection;
 import org.terasology.engine.rendering.dag.stateChanges.BindFbo;
 import org.terasology.engine.rendering.dag.stateChanges.DisableDepthWriting;
 import org.terasology.engine.rendering.dag.stateChanges.EnableBlending;
-import org.terasology.engine.rendering.dag.stateChanges.LookThrough;
 import org.terasology.engine.rendering.dag.stateChanges.SetBlendFunction;
-import org.terasology.engine.rendering.world.WorldRenderer;
+import org.terasology.gestalt.naming.Name;
 
 import static org.lwjgl.opengl.GL11.GL_ONE_MINUS_SRC_ALPHA;
 import static org.lwjgl.opengl.GL11.GL_SRC_ALPHA;
@@ -61,9 +45,6 @@ public class SimpleBlendMaterialsNode extends AbstractNode {
 
     @Override
     public void setDependencies(Context context) {
-        Camera playerCamera = context.get(WorldRenderer.class).getActiveCamera();
-        addDesiredStateChange(new LookThrough(playerCamera));
-
         BufferPairConnection bufferPairConnection = getInputBufferPairConnection(1);
         addOutputBufferPairConnection(1, bufferPairConnection);
         addOutputFboConnection(1, bufferPairConnection.getBufferPair().getPrimaryFbo());


### PR DESCRIPTION
so this LookThrough function just pushes the state to the GL_MODELVIEW and GL_PROJECTION. just need to verify that were not using these calls within these calling methods from these modules in the image provided. 

![image](https://user-images.githubusercontent.com/854359/120088912-551efe80-c0aa-11eb-9152-135530729e9c.png)
