### PR TITLE
bugfix: trying to read back from the buffer right after it is bound is causing the entire pipeline to stall waiting on opengl

### DIFF
--- a/src/main/java/org/terasology/corerendering/rendering/dag/nodes/UpdateExposureNode.java
+++ b/src/main/java/org/terasology/corerendering/rendering/dag/nodes/UpdateExposureNode.java
@@ -1,18 +1,5 @@
-/*
- * Copyright 2017 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.corerendering.rendering.dag.nodes;
 
 import org.lwjgl.opengl.GL11;
@@ -22,15 +9,13 @@ import org.slf4j.LoggerFactory;
 import org.terasology.engine.config.Config;
 import org.terasology.engine.config.RenderingConfig;
 import org.terasology.engine.context.Context;
-import org.terasology.math.TeraMath;
 import org.terasology.engine.monitoring.PerformanceMonitor;
-import org.terasology.gestalt.naming.Name;
-import org.terasology.nui.properties.Range;
 import org.terasology.engine.rendering.dag.AbstractNode;
 import org.terasology.engine.rendering.opengl.PBO;
 import org.terasology.engine.rendering.opengl.ScreenGrabber;
-
-import java.util.concurrent.atomic.AtomicBoolean;
+import org.terasology.gestalt.naming.Name;
+import org.terasology.math.TeraMath;
+import org.terasology.nui.properties.Range;
 
 /**
  * An instance of this node takes advantage of a downsampled version of the scene,


### PR DESCRIPTION
I moved the copyfromFBO after the read. so the PBO is read on the next frame so we don't stall opengl waiting for the rendering logic to catch up. 


https://www.khronos.org/opengl/wiki/Pixel_Buffer_Object

---

PBOs are primarily a performance optimization (though in the days before Transform Feedback, they were a way to rasterize data directly to a buffer object). In particular, PBOs are a way to improve asynchronous behavior between the application and OpenGL.

Therefore, the first thing that you need to do in order to properly take advantage of them is to actually have something to do while you are waiting for the transfer to complete. If you are downloading pixel data, and you map the buffer for reading immediately after calling glReadPixels, you aren't getting anything from PBOs.

There are two circumstances for PBOs: uploading and downloading. Both have different needs. 

---

PR: https://github.com/MovingBlocks/Terasology/pull/4760