### PR TITLE
chore: cleanup core rendering and migrate in shaders from Engine

### DIFF
--- a/assets/materials/blur.mat
+++ b/assets/materials/blur.mat
@@ -1,0 +1,4 @@
+{
+  "shader": "CoreRendering:blur",
+  "params": {}
+}

--- a/assets/materials/chunk.mat
+++ b/assets/materials/chunk.mat
@@ -1,0 +1,4 @@
+{
+  "shader": "CoreRendering:chunk",
+  "params": {}
+}

--- a/assets/materials/downSampler.mat
+++ b/assets/materials/downSampler.mat
@@ -1,0 +1,4 @@
+{
+  "shader": "CoreRendering:downSampler",
+  "params": {}
+}

--- a/assets/materials/highPass.mat
+++ b/assets/materials/highPass.mat
@@ -1,0 +1,4 @@
+{
+  "shader": "CoreRendering:highPass",
+  "params": {}
+}

--- a/assets/materials/initialPost.mat
+++ b/assets/materials/initialPost.mat
@@ -1,0 +1,4 @@
+{
+  "shader": "CoreRendering:initialPost",
+  "params": {}
+}

--- a/assets/materials/lightBufferPass.mat
+++ b/assets/materials/lightBufferPass.mat
@@ -1,0 +1,4 @@
+{
+  "shader": "CoreRendering:lightBufferPass",
+  "params": {}
+}

--- a/assets/materials/lightGeometryPass.mat
+++ b/assets/materials/lightGeometryPass.mat
@@ -1,0 +1,4 @@
+{
+  "shader": "CoreRendering:lightGeometryPass",
+  "params": {}
+}

--- a/assets/materials/lightShafts.mat
+++ b/assets/materials/lightShafts.mat
@@ -1,0 +1,4 @@
+{
+  "shader": "CoreRendering:lightShafts",
+  "params": {}
+}

--- a/assets/materials/outputPass.mat
+++ b/assets/materials/outputPass.mat
@@ -1,0 +1,4 @@
+{
+  "shader": "CoreRendering:outputPass",
+  "params": {}
+}

--- a/assets/materials/post.mat
+++ b/assets/materials/post.mat
@@ -1,0 +1,4 @@
+{
+  "shader": "CoreRendering:post",
+  "params": {}
+}

--- a/assets/materials/prePostComposite.mat
+++ b/assets/materials/prePostComposite.mat
@@ -1,0 +1,4 @@
+{
+  "shader": "CoreRendering:prePostComposite",
+  "params": {}
+}

--- a/assets/materials/shadowMap.mat
+++ b/assets/materials/shadowMap.mat
@@ -1,0 +1,4 @@
+{
+  "shader": "CoreRendering:shadowMap",
+  "params": {}
+}

--- a/assets/materials/sky.mat
+++ b/assets/materials/sky.mat
@@ -1,0 +1,4 @@
+{
+  "shader": "CoreRendering:sky",
+  "params": {}
+}

--- a/assets/materials/sobel.mat
+++ b/assets/materials/sobel.mat
@@ -1,0 +1,4 @@
+{
+  "shader": "CoreRendering:sobel",
+  "params": {}
+}

--- a/assets/materials/ssao.mat
+++ b/assets/materials/ssao.mat
@@ -1,0 +1,4 @@
+{
+  "shader": "CoreRendering:ssao",
+  "params": {}
+}

--- a/assets/materials/ssaoBlur.mat
+++ b/assets/materials/ssaoBlur.mat
@@ -1,0 +1,4 @@
+{
+  "shader": "CoreRendering:ssaoBlur",
+  "params": {}
+}

--- a/assets/materials/toneMapping.mat
+++ b/assets/materials/toneMapping.mat
@@ -1,0 +1,4 @@
+{
+  "shader": "CoreRendering:toneMapping",
+  "params": {}
+}

--- a/assets/materials/vignette.mat
+++ b/assets/materials/vignette.mat
@@ -1,0 +1,4 @@
+{
+  "shader": "CoreRendering:vignette",
+  "params": {}
+}

--- a/assets/shaders/blur_frag.glsl
+++ b/assets/shaders/blur_frag.glsl
@@ -1,0 +1,30 @@
+#version 330 core
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+in vec2 v_uv0;
+
+uniform sampler2D tex;
+
+uniform float radius = 16.0;
+uniform vec2 texelSize = vec2(1.0/1024.0, 1.0/1024.0);
+
+const vec2 taps[12] = vec2[12](
+    vec2(-0.326212,-0.40581), vec2(-0.840144,-0.07358),
+    vec2(-0.695914,0.457137), vec2(-0.203345,0.620716),
+    vec2(0.96234,-0.194983), vec2(0.473434,-0.480026),
+    vec2(0.519456,0.767022), vec2(0.185461,-0.893124),
+    vec2(0.507431,0.064425), vec2(0.89642,0.412458),
+    vec2(-0.32194,-0.932615), vec2(-0.791559,-0.59771)
+);
+
+void main() {
+    vec4 sampleAccum = vec4(0.0, 0.0, 0.0, 0.0);
+
+    for (int nTapIndex = 0; nTapIndex < 12; nTapIndex++) {
+        vec2 tapcoord = v_uv0.xy + texelSize * taps[nTapIndex] * radius;
+        sampleAccum += texture2D(tex, tapcoord);
+    }
+
+    gl_FragData[0].rgba = sampleAccum / 12.0;
+}

--- a/assets/shaders/blur_vert.glsl
+++ b/assets/shaders/blur_vert.glsl
@@ -1,0 +1,14 @@
+#version 330 core
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+layout (location = 0) in vec3 in_vert;
+layout (location = 1) in vec3 in_normal;
+layout (location = 2) in vec2 in_uv0;
+layout (location = 4) in vec4 in_color0;
+
+out vec2 v_uv0;
+
+void main() {
+    gl_Position = vec4(in_vert, 1.0);
+    v_uv0 = in_uv0;
+}

--- a/assets/shaders/chunk_frag.glsl
+++ b/assets/shaders/chunk_frag.glsl
@@ -1,0 +1,276 @@
+#version 330 core
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+#define WATER_COLOR_SWIMMING 0.8, 1.0, 1.0, 0.975
+#define WATER_TINT 0.1, 0.41, 0.627, 1.0
+
+#define WATER_SPEC 1.0
+
+#ifdef FEATURE_REFRACTIVE_PASS
+uniform vec4 waterSettingsFrag;
+#define waterNormalBias waterSettingsFrag.x
+#define waterRefraction waterSettingsFrag.y
+#define waterFresnelBias waterSettingsFrag.z
+#define waterFresnelPow waterSettingsFrag.w
+
+uniform vec4 alternativeWaterSettingsFrag;
+#define waterTint alternativeWaterSettingsFrag.x
+uniform vec4 lightingSettingsFrag;
+#define waterSpecExp lightingSettingsFrag.z
+
+uniform sampler2D textureWater;
+uniform sampler2D textureWaterReflection;
+uniform sampler2D texSceneOpaque;
+uniform sampler2D textureWaterNormal;
+uniform sampler2D textureWaterNormalAlt;
+
+in vec3 waterNormalViewSpace;
+#endif
+
+#if defined (NORMAL_MAPPING)
+in vec3 worldSpaceNormal;
+uniform sampler2D textureAtlasNormal;
+#endif
+
+#if defined (PARALLAX_MAPPING)
+uniform vec4 parallaxProperties;
+#define parallaxBias parallaxProperties.x
+#define parallaxScale parallaxProperties.y
+
+uniform sampler2D textureAtlasHeight;
+#endif
+
+
+#if defined (FLICKERING_LIGHT)
+in float flickeringLightOffset;
+#endif
+
+in vec3 vertexWorldPos;
+in vec4 vertexViewPos;
+in vec4 vertexProjPos;
+in vec3 sunVecView;
+
+in vec3 normal;
+
+in vec2 v_uv0;
+flat in int v_blockHint;
+flat in int isUpside;
+
+uniform sampler2D textureAtlas;
+uniform sampler2D textureEffects;
+
+uniform float clip;
+
+in float v_sunlight;
+in float v_blocklight;
+in float v_ambientLight;
+
+//inverse is not available in GLSL 1.20, so calculate it manually
+mat2 inverse2(mat2 m) {
+    float det = m[0][0] * m[1][1] - m[1][0] * m[0][1];
+    return mat2(m[1][1], -m[0][1], -m[1][0], m[0][0]) / det;
+}
+
+void main() {
+
+// Active for worldReflectionNode only.
+#if defined FEATURE_USE_FORWARD_LIGHTING
+    if (vertexWorldPos.y < clip) {
+        discard;
+    }
+#endif
+
+    vec2 texCoord = v_uv0.xy;
+
+    vec3 normalizedViewPos = -normalize(vertexViewPos.xyz);
+    vec2 projectedPos = projectVertexToTexCoord(vertexProjPos);
+    vec3 normalOpaque = normal;
+    float shininess = 0.0;
+
+#if defined (NORMAL_MAPPING) || defined (PARALLAX_MAPPING)
+    // TODO: Calculates the tangent frame on the fly - this is absurdly costly... But storing
+    // the tangent for each vertex in the chunk VBO might be not the best idea either.
+    // The only reason dFdx and dFdy are used here is that it happens to be possible to relate
+    // both view and UV coordinates to screen-space coordinated. The specific relationship between
+    // screen coordinates and view coordinates is irrelevant.
+    mat2x3 screenToView = mat2x3(dFdx(vertexViewPos.xyz), dFdy(vertexViewPos.xyz));
+    mat2   screenToUv   = mat2  (dFdx(v_uv0.xy), dFdy(v_uv0.xy)) / TEXTURE_OFFSET;
+    mat2 uvToScreen = inverse2(screenToUv);
+    mat2x3 uvToView = screenToView * uvToScreen;
+
+    #if defined (PARALLAX_MAPPING)
+        vec2 viewDirectionUvProjection = -normalizedViewPos * uvToView;
+
+        float height = parallaxScale * texture2D(textureAtlasHeight, texCoord).r - parallaxBias;
+        // Ideally this should be divided by dot(normal, normalizedViewPos), as the offset for texCoord
+        // is the component parallel to the surface of a vector along the view's forward axis,
+        // the other component being a vector perpendicular to the surface and having magnitude "height".
+        // In practice the current way looks better at low angles, as the height-map can't make the triangle
+        // protrude beyond its boundaries like displacement mapping would.
+        texCoord += height * viewDirectionUvProjection * TEXTURE_OFFSET;
+
+        //Crudely prevent the parallax from extending to other textures in the same atlas.
+        vec2 texCorner = floor(v_uv0.xy/TEXTURE_OFFSET)*TEXTURE_OFFSET;
+        vec2 texSize = vec2(1,1)*TEXTURE_OFFSET*0.9999; //Remain strictly this side of the edge of the texture.
+        texCoord = clamp(texCoord, texCorner, texCorner + texSize);
+    #endif
+    #if defined (NORMAL_MAPPING)
+        // Normalised but not orthonormalised. It should be orthogonal anyway (except for some non-rectangular
+        // block shapes like torches), but it's not obvious what's the best thing to do when it isn't.
+        mat3 uvnSpaceToViewSpace = mat3(normalize(uvToView[0]), normalize(uvToView[1]), normal);
+        normalOpaque = normalize(texture2D(textureAtlasNormal, texCoord).xyz * 2.0 - 1.0);
+        normalOpaque = normalize(uvnSpaceToViewSpace * normalOpaque);
+
+        shininess = texture2D(textureAtlasNormal, texCoord).w;
+    #endif
+#endif
+
+#ifdef FEATURE_REFRACTIVE_PASS
+    vec2 normalWaterOffset;
+    vec3 normalWater = waterNormalViewSpace;
+    bool isWater = false;
+    bool isOceanWater = false;
+
+    if (BLOCK_HINT_WATER_SURFACE == v_blockHint && isUpside == 1) {
+        vec2 scaledVertexWorldPos = vertexWorldPos.xz / 32.0;
+
+        vec2 waterOffset = vec2(scaledVertexWorldPos.x + timeToTick(time, 0.0075), scaledVertexWorldPos.y + timeToTick(time, 0.0075));
+        vec2 waterOffset2 = vec2(scaledVertexWorldPos.x + timeToTick(time, 0.005), scaledVertexWorldPos.y - timeToTick(time, 0.005));
+
+        normalWaterOffset = (texture2D(textureWaterNormal, waterOffset).xyz * 2.0 - 1.0).xy;
+        normalWaterOffset += (texture2D(textureWaterNormalAlt, waterOffset2).xyz * 2.0 - 1.0).xy;
+        normalWaterOffset *= 0.5 * (1.0 / vertexViewPos.z * waterNormalBias);
+
+        normalWater.xy += normalWaterOffset;
+        normalWater = normalize(normalWater);
+
+        isOceanWater = true;
+        isWater = true;
+    }
+#endif
+
+#if defined (FEATURE_REFRACTIVE_PASS) || defined (FEATURE_USE_FORWARD_LIGHTING)
+    vec3 sunVecViewAdjusted = sunVecView;
+
+    /* DAYLIGHT BECOMES... MOONLIGHT! */
+    // Now featuring linear interpolation to make the transition smoother... :-)
+    if (daylight < 0.1) {
+        sunVecViewAdjusted = mix(sunVecViewAdjusted * -1.0, sunVecViewAdjusted, daylight / 0.1);
+    }
+#endif
+
+    vec4 color = vec4(0.0, 0.0, 0.0, 1.0);
+
+#if !defined (FEATURE_REFRACTIVE_PASS)
+    color = texture2D(textureAtlas, texCoord.xy);
+
+    #if defined FEATURE_ALPHA_REJECT
+        if (color.a < 0.1) {
+            discard;
+        }
+    #endif
+#endif
+
+    // Calculate daylight lighting value
+    float daylightValue = v_sunlight;
+    // Calculate blocklight lighting value
+    float blocklightValue = v_blocklight;
+    // ...and finally the occlusion value
+    float occlusionValue = expOccValue(v_ambientLight);
+
+    float blocklightColorBrightness = calcBlocklightColorBrightness(blocklightValue
+    #if defined (FLICKERING_LIGHT)
+            , flickeringLightOffset
+    #endif
+    );
+    vec3 blocklightColorValue = calcBlocklightColor(blocklightColorBrightness);
+
+#if defined (FEATURE_REFRACTIVE_PASS)
+    vec3 daylightColorValue;
+
+    if (isOceanWater) {
+        daylightColorValue = calcSunlightColorWater(daylightValue, normalWater, sunVecViewAdjusted);
+    } else {
+        daylightColorValue = calcSunlightColorOpaque(daylightValue, normal, sunVecViewAdjusted);
+    }
+
+    vec3 combinedLightValue = max(daylightColorValue, blocklightColorValue);
+#elif defined (FEATURE_USE_FORWARD_LIGHTING)
+    vec3 daylightColorValue = calcSunlightColorOpaque(daylightValue, normal, sunVecViewAdjusted);
+    vec3 combinedLightValue = max(daylightColorValue, blocklightColorValue);
+#endif
+
+#if defined (FEATURE_REFRACTIVE_PASS)
+    // Apply the final lighting mix
+    color.xyz *= combinedLightValue * occlusionValue;
+
+    // Apply reflection and refraction AFTER the lighting has been applied (otherwise bright areas below water become dark)
+    // The water tint has still to be adjusted adjusted though...
+    if (isWater && isOceanWater) {
+        float specularHighlight = WATER_SPEC * calcDayAndNightLightingFactor(daylightValue, daylight) * calcSpecLightNormalized(normalWater, sunVecViewAdjusted, normalizedViewPos, waterSpecExp);
+        color.xyz += vec3(specularHighlight, specularHighlight, specularHighlight);
+
+        vec4 reflectionColor = vec4(texture2D(textureWaterReflection, projectedPos + normalWaterOffset.xy * waterRefraction).xyz, 1.0);
+        vec4 refractionColor = vec4(texture2D(texSceneOpaque, projectedPos + normalWaterOffset.xy * waterRefraction).xyz, 1.0);
+
+        vec4 litWaterTint = vec4(WATER_TINT) * vec4(combinedLightValue.x, combinedLightValue.y, combinedLightValue.z, 1.0);
+
+        /* FRESNEL */
+        if (!swimming) {
+            float f = fresnel(dot(normalWater, normalizedViewPos), waterFresnelBias, waterFresnelPow);
+            color += mix(refractionColor * (1.0 - waterTint) +  waterTint * litWaterTint,
+                    reflectionColor * (1.0 - waterTint) + waterTint * litWaterTint, f);
+        } else {
+             color += refractionColor * (1.0 - waterTint) +  waterTint * litWaterTint;
+        }
+
+        color.a = 1.0;
+    } else if (isWater) {
+        texCoord.x = mod(texCoord.x, TEXTURE_OFFSET) * (1.0 / TEXTURE_OFFSET);
+        texCoord.y = mod(texCoord.y, TEXTURE_OFFSET) / (128.0 / (1.0 / TEXTURE_OFFSET));
+        texCoord.y += mod(timeToTick(time, -0.1), 127.0) * (1.0/128.0);
+
+        vec4 albedoColor = texture2D(textureWater, texCoord.xy).rgba;
+        albedoColor.rgb *= combinedLightValue;
+
+        vec3 refractionColor = texture2D(texSceneOpaque, projectedPos + albedoColor.rg * 0.05).rgb;
+
+        color.rgb += mix(refractionColor, albedoColor.rgb, albedoColor.a);
+        color.a = 1.0;
+    } else {
+        vec3 refractionColor = texture2D(texSceneOpaque, projectedPos).rgb;
+        vec4 albedoColor = texture2D(textureAtlas, texCoord.xy);
+        albedoColor.rgb *= combinedLightValue;
+
+        // TODO: Add support for actual refraction here
+        color.rgb += mix(refractionColor, albedoColor.rgb, albedoColor.a);
+        color.a = 1.0;
+    }
+#elif defined (FEATURE_USE_FORWARD_LIGHTING)
+    // Apply the final lighting mix
+    color.xyz *= combinedLightValue * occlusionValue;
+#else
+    gl_FragData[2].rgba = vec4(blocklightColorBrightness, daylightValue, 0.0, 0.0);
+#endif
+
+#if defined (FEATURE_REFRACTIVE_PASS) || defined (FEATURE_USE_FORWARD_LIGHTING)
+    gl_FragData[0].rgba = color.rgba;
+#if defined (FEATURE_REFRACTIVE_PASS)
+    // Encode "reflection" intensity into normal alpha
+    gl_FragData[1].a = 1.0;
+#endif
+#else
+    gl_FragData[0].rgb = color.rgb;
+    // Encode occlusion value into the alpha channel
+    gl_FragData[0].a = occlusionValue;
+    // Encode shininess value into the normal alpha channel
+    gl_FragData[1].a = shininess;
+#endif
+
+#if !defined (FEATURE_REFRACTIVE_PASS) && !defined (FEATURE_USE_FORWARD_LIGHTING)
+    gl_FragData[1].rgb = vec3(normalOpaque.x / 2.0 + 0.5, normalOpaque.y / 2.0 + 0.5, normalOpaque.z / 2.0 + 0.5);
+#elif defined (FEATURE_REFRACTIVE_PASS)
+    gl_FragData[1].rgb = vec3(normalWater.x / 2.0 + 0.5, normalWater.y / 2.0 + 0.5, normalWater.z / 2.0 + 0.5);
+#endif
+}

--- a/assets/shaders/chunk_vert.glsl
+++ b/assets/shaders/chunk_vert.glsl
@@ -1,0 +1,190 @@
+#version 330 core
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+#ifdef FEATURE_REFRACTIVE_PASS
+out vec3 waterNormalViewSpace;
+#endif
+
+#if defined (ANIMATED_WATER) && defined (FEATURE_REFRACTIVE_PASS)
+const vec3 normalDiffOffset = vec3(-1.0, 0.0, 1.0);
+const vec2 normalDiffSize = vec2(2.0, 0.0);
+
+uniform float waveIntensityFalloff;
+uniform float waveSizeFalloff;
+uniform float waveSpeedFalloff;
+uniform float waveSize;
+uniform float waveIntensity;
+uniform float waveSpeed;
+uniform float waterOffsetY;
+uniform float waveOverallScale;
+
+const vec2[] waveDirections = vec2[](
+    vec2(-0.613392, 0.617481),
+    vec2(0.170019, -0.040254),
+    vec2(-0.299417, 0.791925),
+    vec2(0.645680, 0.493210),
+    vec2(-0.651784, 0.717887),
+    vec2(0.421003, 0.027070),
+    vec2(-0.817194, -0.271096),
+    vec2(-0.705374, -0.668203),
+    vec2(0.977050, -0.108615),
+    vec2(0.063326, 0.142369),
+    vec2(0.203528, 0.214331),
+    vec2(-0.667531, 0.326090),
+    vec2(-0.098422, -0.295755),
+    vec2(-0.885922, 0.215369),
+    vec2(0.566637, 0.605213),
+    vec2(0.039766, -0.396100)
+);
+
+float calcWaterHeightAtOffset(vec2 worldPos) {
+    float height = 0.0;
+
+    float size = waveSize;
+    float intens = waveIntensity;
+    float timeFactor = waveSpeed;
+    for (int i=0; i<OCEAN_OCTAVES; ++i) {
+        height += (smoothTriangleWave(timeToTick(time, timeFactor) + worldPos.x * waveDirections[i].x
+            * size + worldPos.y * waveDirections[i].y * size) * 2.0 - 1.0) * intens;
+
+        size *= waveSizeFalloff;
+        intens *= waveIntensityFalloff;
+        timeFactor *= waveSpeedFalloff;
+    }
+
+    return (height / float(OCEAN_OCTAVES)) * waveOverallScale;
+}
+
+vec4 calcWaterNormalAndOffset(vec2 worldPosRaw) {
+    float s11 = calcWaterHeightAtOffset(worldPosRaw.xy);
+    float s01 = calcWaterHeightAtOffset(worldPosRaw.xy + normalDiffOffset.xy);
+    float s21 = calcWaterHeightAtOffset(worldPosRaw.xy + normalDiffOffset.zy);
+    float s10 = calcWaterHeightAtOffset(worldPosRaw.xy + normalDiffOffset.yx);
+    float s12 = calcWaterHeightAtOffset(worldPosRaw.xy + normalDiffOffset.yz);
+
+    vec3 va = normalize(vec3(normalDiffSize.x, s21-s01, normalDiffSize.y));
+    vec3 vb = normalize(vec3(normalDiffSize.y, s10-s12, -normalDiffSize.x));
+
+    return vec4(cross(va,vb), s11);
+}
+#endif
+
+#if defined (FLICKERING_LIGHT)
+out float flickeringLightOffset;
+#endif
+
+#if defined (NORMAL_MAPPING)
+out vec3 worldSpaceNormal;
+#endif
+
+uniform float blockScale = 1.0;
+uniform vec3 chunkPositionWorld;
+
+// waving blocks
+uniform bool animated;
+
+uniform mat4 modelViewMatrix;
+uniform mat4 projectionMatrix;
+uniform mat3 normalMatrix;
+
+out vec3 normal;
+
+out vec3 vertexWorldPos;
+out vec4 vertexViewPos;
+out vec4 vertexProjPos;
+
+out vec3 sunVecView;
+
+out vec2 v_uv0;
+out float v_sunlight;
+out float v_blocklight;
+out float v_ambientLight;
+flat out int isUpside;
+flat out int v_blockHint;
+
+layout (location = 0) in vec3 in_vert;
+layout (location = 1) in vec3 in_normal;
+layout (location = 2) in vec2 in_uv0;
+
+layout (location = 3) in int in_flags;
+layout (location = 4) in float in_frames;
+
+layout (location = 5) in float in_sunlight;
+layout (location = 6) in float in_blocklight;
+layout (location = 7) in float in_ambientlight;
+
+void main() {
+
+    v_uv0 = in_uv0;
+    v_sunlight = in_sunlight;
+    v_blocklight = in_blocklight;
+    v_ambientLight = in_ambientlight;
+    v_blockHint = in_flags;
+    vertexViewPos = modelViewMatrix * vec4(in_vert, 1.0);
+    vertexWorldPos = in_vert + chunkPositionWorld.xyz;
+
+    if (in_frames > 0) {
+        float globalFrameIndex = floor(time * 6 *60*60*24/48); // 6Hz at default world time scale
+        float frameIndex = mod(globalFrameIndex, in_frames);
+        float frame_x = in_uv0.x + (frameIndex * TEXTURE_OFFSET);
+        v_uv0.y = in_uv0.y + floor(frame_x) * TEXTURE_OFFSET;
+        v_uv0.x = mod(frame_x, 1);
+    }
+
+    sunVecView = (modelViewMatrix * vec4(sunVec.x, sunVec.y, sunVec.z, 0.0)).xyz;
+
+    isUpside = in_normal.y > 0.9 ? 1 : 0;
+
+#if defined (NORMAL_MAPPING)
+    worldSpaceNormal = in_normal;
+#endif
+    normal = normalMatrix * in_normal;
+
+
+#ifdef FLICKERING_LIGHT
+    flickeringLightOffset = smoothTriangleWave(timeToTick(time, 0.5)) / 16.0;
+    flickeringLightOffset += smoothTriangleWave(timeToTick(time, 0.25) + 0.3762618) / 8.0;
+    flickeringLightOffset += smoothTriangleWave(timeToTick(time, 0.1) + 0.872917) / 4.0;
+#endif
+
+#ifdef ANIMATED_GRASS
+    if (animated) {
+        // GRASS ANIMATION
+        if (v_blockHint == BLOCK_HINT_WAVING) {
+           // Only animate the upper two vertices
+           if (mod(v_uv0.y, TEXTURE_OFFSET) < TEXTURE_OFFSET / 2.0) {
+               vertexViewPos.x += (smoothTriangleWave(timeToTick(time, 0.2) + vertexWorldPos.x * 0.1 + vertexWorldPos.z * 0.1) * 2.0 - 1.0) * 0.1 * blockScale;
+               vertexViewPos.y += (smoothTriangleWave(timeToTick(time, 0.1) + vertexWorldPos.x * -0.5 + vertexWorldPos.z * -0.5) * 2.0 - 1.0) * 0.05 * blockScale;
+           }
+        } else if (v_blockHint == BLOCK_HINT_WAVING_BLOCK) {
+            vertexViewPos.x += (smoothTriangleWave(timeToTick(time, 0.1) + vertexWorldPos.x * 0.01 + vertexWorldPos.z * 0.01) * 2.0 - 1.0) * 0.01 * blockScale;
+            vertexViewPos.y += (smoothTriangleWave(timeToTick(time, 0.15) + vertexWorldPos.x * -0.01 + vertexWorldPos.z * -0.01) * 2.0 - 1.0) * 0.05 * blockScale;
+            vertexViewPos.z += (smoothTriangleWave(timeToTick(time, 0.1) + vertexWorldPos.x * -0.01 + vertexWorldPos.z * -0.01) * 2.0 - 1.0) * 0.01 * blockScale;
+        }
+    }
+#endif
+
+#if defined (FEATURE_REFRACTIVE_PASS)
+    #if defined (ANIMATED_WATER)
+        if (v_blockHint == BLOCK_HINT_WATER_SURFACE && isUpside == 1) {
+            vec4 normalAndOffset = calcWaterNormalAndOffset(vertexWorldPos.xz);
+
+            waterNormalViewSpace = normalMatrix * normalAndOffset.xyz;
+            vertexViewPos += modelViewMatrix[1] * (normalAndOffset.w + waterOffsetY);
+        }
+    #else
+        waterNormalViewSpace = normalMatrix * vec3(0.0, 1.0, 0.0);
+    #endif
+#endif
+
+    vertexProjPos = projectionMatrix * vertexViewPos;
+    gl_Position = vertexProjPos;
+
+#if defined (FEATURE_ALPHA_REJECT)
+    //TODO: find the right methods to determine which vertices have normals facing away from the viewpoint, and only alter those
+    //if (normal.x * vertexViewPos.x < 0 || normal.y * vertexViewPos.y < 0 || normal.z * vertexViewPos.z < 0) {
+        gl_Position.z -= 0.001;
+    //}
+#endif
+}

--- a/assets/shaders/downSampler_frag.glsl
+++ b/assets/shaders/downSampler_frag.glsl
@@ -1,0 +1,31 @@
+#version 330 core
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+in vec2 v_uv0;
+
+uniform sampler2D tex;
+uniform float size;
+
+const vec2 s1 = vec2(-1, 1);
+const vec2 s2 = vec2( 1, 1);
+const vec2 s3 = vec2( 1,-1);
+const vec2 s4 = vec2(-1,-1);
+
+void main() {
+    vec2 texCoordSample = vec2(0.0);
+
+	texCoordSample = v_uv0.xy + s1 / size;
+	vec4 color = texture2D(tex, texCoordSample);
+
+	texCoordSample = v_uv0.xy + s2 / size;
+	color += texture2D(tex, texCoordSample);
+
+	texCoordSample = v_uv0.xy + s3 / size;
+	color += texture2D(tex, texCoordSample);
+
+	texCoordSample = v_uv0.xy + s4 / size;
+	color += texture2D(tex, texCoordSample);
+
+	gl_FragData[0].rgba = color * 0.25;
+}

--- a/assets/shaders/downSampler_vert.glsl
+++ b/assets/shaders/downSampler_vert.glsl
@@ -1,0 +1,15 @@
+#version 330 core
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+layout (location = 0) in vec3 in_vert;
+layout (location = 1) in vec3 in_normal;
+layout (location = 2) in vec2 in_uv0;
+layout (location = 4) in vec4 in_color0;
+
+out vec2 v_uv0;
+
+void main() {
+    gl_Position = vec4(in_vert, 1.0);
+    v_uv0 = in_uv0;
+}

--- a/assets/shaders/highPass_frag.glsl
+++ b/assets/shaders/highPass_frag.glsl
@@ -1,0 +1,22 @@
+#version 330 core
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+in vec2 v_uv0;
+
+uniform sampler2D tex;
+uniform float highPassThreshold;
+
+void main() {
+    vec4 color = texture(tex, v_uv0.xy);
+
+    // vec3 brightColor = max(color.rgb - vec3(highPassThreshold), vec3(0.0));
+    float relativeLuminance = dot(vec3(0.2126, 0.7152, 0.0722),color.rgb - vec3(highPassThreshold));
+    // bright = smoothstep(0.0, 0.5, bright);
+
+    if(relativeLuminance * highPassThreshold > 1.0) {
+        gl_FragData[0].rgba = vec4(color.rgb, 1);
+    } else {
+        gl_FragData[0].rgba = vec4(0);
+    }
+}

--- a/assets/shaders/highPass_vert.glsl
+++ b/assets/shaders/highPass_vert.glsl
@@ -1,0 +1,15 @@
+#version 330 core
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+layout (location = 0) in vec3 in_vert;
+layout (location = 1) in vec3 in_normal;
+layout (location = 2) in vec2 in_uv0;
+layout (location = 4) in vec4 in_color0;
+
+out vec2 v_uv0;
+
+void main() {
+    gl_Position = vec4(in_vert, 1.0);
+    v_uv0 = in_uv0;
+}

--- a/assets/shaders/initialPost_frag.glsl
+++ b/assets/shaders/initialPost_frag.glsl
@@ -1,0 +1,33 @@
+#version 330 core
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+#ifdef BLOOM
+uniform float bloomFactor;
+
+uniform sampler2D texBloom;
+#endif
+
+uniform sampler2D texScene;
+
+#ifdef LIGHT_SHAFTS
+uniform sampler2D texLightShafts;
+#endif
+
+in vec2 v_uv0;
+
+void main() {
+
+    vec4 color = texture(texScene, v_uv0.xy);
+#ifdef LIGHT_SHAFTS
+    vec4 colorShafts = texture(texLightShafts, v_uv0.xy);
+    color.rgb += colorShafts.rgb;
+#endif
+
+#ifdef BLOOM
+    vec4 colorBloom = texture(texBloom, v_uv0.xy);
+    color += colorBloom * bloomFactor;
+#endif
+
+    gl_FragData[0].rgba = color.rgba;
+}

--- a/assets/shaders/initialPost_vert.glsl
+++ b/assets/shaders/initialPost_vert.glsl
@@ -1,0 +1,15 @@
+#version 330 core
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+layout (location = 0) in vec3 in_vert;
+layout (location = 1) in vec3 in_normal;
+layout (location = 2) in vec2 in_uv0;
+layout (location = 4) in vec4 in_color0;
+
+out vec2 v_uv0;
+
+void main() {
+    gl_Position = vec4(in_vert, 1.0);
+    v_uv0 = in_uv0;
+}

--- a/assets/shaders/lightBufferPass_frag.glsl
+++ b/assets/shaders/lightBufferPass_frag.glsl
@@ -1,0 +1,38 @@
+#version 330 core
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+in vec2 v_uv0;
+
+uniform sampler2D texSceneOpaque;
+uniform sampler2D texSceneOpaqueDepth;
+uniform sampler2D texSceneOpaqueNormals;
+uniform sampler2D texSceneOpaqueLightBuffer;
+
+void main() {
+    vec4 colorOpaque = texture(texSceneOpaque, v_uv0.xy);
+    float depthOpaque = texture(texSceneOpaqueDepth, v_uv0.xy).r * 2.0 - 1.0;
+    vec4 normalBuffer = texture(texSceneOpaqueNormals, v_uv0.xy).rgba;
+    vec4 lightBufferOpaque = texture(texSceneOpaqueLightBuffer, v_uv0.xy);
+    vec3 blocklightColor = calcBlocklightColor(lightBufferOpaque.x);
+    float sunlightIntensity = lightBufferOpaque.y;
+
+    if (!epsilonEqualsOne(depthOpaque)) {
+        // Diffuse
+        colorOpaque.rgb *= blocklightColor.rgb;
+#if !defined (SSAO)
+        // Occlusion
+        colorOpaque.rgb *= colorOpaque.a;
+#endif
+        // Specular
+        colorOpaque.rgb += lightBufferOpaque.aaa;
+    }
+
+    gl_FragData[0].rgba = colorOpaque.rgba;
+    gl_FragData[1].rgba = normalBuffer.rgba;
+    gl_FragData[2].rgb = blocklightColor.rgb;
+    gl_FragData[2].a = sunlightIntensity;
+
+
+    gl_FragDepth = depthOpaque * 0.5 + 0.5;
+}

--- a/assets/shaders/lightBufferPass_vert.glsl
+++ b/assets/shaders/lightBufferPass_vert.glsl
@@ -1,0 +1,14 @@
+#version 330 core
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+layout (location = 0) in vec3 in_vert;
+layout (location = 1) in vec3 in_normal;
+layout (location = 2) in vec2 in_uv0;
+layout (location = 4) in vec4 in_color0;
+
+out vec2 v_uv0;
+
+void main() {
+    gl_Position = vec4(in_vert, 1.0);
+    v_uv0 = in_uv0;
+}

--- a/assets/shaders/lightGeometryPass_frag.glsl
+++ b/assets/shaders/lightGeometryPass_frag.glsl
@@ -1,0 +1,173 @@
+#version 330 core
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+in vec2 v_uv0;
+in vec4 v_vertexProjPos;
+
+uniform vec3 lightViewPos;
+
+uniform sampler2D texSceneOpaqueDepth;
+uniform sampler2D texSceneOpaqueNormals;
+#if defined (FEATURE_LIGHT_DIRECTIONAL)
+uniform sampler2D texSceneOpaqueLightBuffer;
+#endif
+
+uniform vec3 lightColorDiffuse = vec3(1.0, 0.0, 0.0);
+uniform vec3 lightColorAmbient = vec3(1.0, 0.0, 0.0);
+
+uniform vec3 lightProperties;
+#define lightAmbientIntensity lightProperties.x
+#define lightDiffuseIntensity lightProperties.y
+#define lightSpecularPower lightProperties.z
+
+uniform vec4 lightExtendedProperties;
+#define lightAttenuationRange lightExtendedProperties.x
+#define lightAttenuationFalloff lightExtendedProperties.y
+
+
+#if defined (DYNAMIC_SHADOWS)
+    #if defined (CLOUD_SHADOWS)
+    uniform sampler2D texSceneClouds;
+    #endif
+
+    #define SHADOW_MAP_BIAS 0.0001
+
+    #if defined (FEATURE_LIGHT_DIRECTIONAL)
+    uniform sampler2D texSceneShadowMap;
+    #endif
+
+    uniform vec3 activeCameraToLightSpace;
+    uniform mat4 lightMatrix;
+    uniform mat4 invViewProjMatrix;
+#endif
+
+uniform mat4 invProjMatrix;
+
+void main() {
+
+#if defined (FEATURE_LIGHT_POINT)
+    vec2 projectedPos = projectVertexToTexCoord(v_vertexProjPos);
+#elif defined (FEATURE_LIGHT_DIRECTIONAL)
+    vec2 projectedPos = v_uv0.xy;
+#else
+    vec2 projectedPos = vec2(0.0);
+#endif
+
+    vec4 normalBuffer = texture2D(texSceneOpaqueNormals, projectedPos.xy).rgba;
+    vec3 normal = normalize(normalBuffer.xyz * 2.0 - 1.0);
+    float shininess = normalBuffer.a;
+    highp float depth = texture2D(texSceneOpaqueDepth, projectedPos.xy).r * 2.0 - 1.0;
+
+    vec3 lightDir;
+    // TODO: Costly - would be nice to use Crytek's view frustum ray method at this point
+    vec3 viewSpacePos = reconstructViewPos(depth, projectedPos, invProjMatrix);
+
+#if defined (FEATURE_LIGHT_POINT)
+    lightDir = lightViewPos.xyz - viewSpacePos;
+#elif defined (FEATURE_LIGHT_DIRECTIONAL)
+    lightDir = lightViewPos.xyz;
+#endif
+
+
+#if defined (DYNAMIC_SHADOWS) && defined (FEATURE_LIGHT_DIRECTIONAL)
+    // TODO: Uhhh... Doing this twice here :/ Frustum ray would be better!
+    vec3 worldPosition = reconstructViewPos(depth, v_uv0.xy, invViewProjMatrix);
+    vec3 lightWorldPosition = worldPosition.xyz + activeCameraToLightSpace;
+
+    vec4 shadowMapTexPos = lightMatrix * vec4(lightWorldPosition.x, lightWorldPosition.y, lightWorldPosition.z, 1.0);
+    highp float shadowTerm = 0.0;
+    highp float bias = max(SHADOW_MAP_BIAS * (1.0 - dot(normal, lightDir)), SHADOW_MAP_BIAS);
+
+    #if defined (DYNAMIC_SHADOWS_PCF)
+        vec2 texelSize = 1.0 / textureSize(texSceneShadowMap, 0);
+        for(int x = -1; x <= 1; ++x) {
+            for(int y = -1; y <= 1; ++y) {
+                vec2 shadowPos = shadowMapTexPos.xy + vec2(x, y) * texelSize;
+                highp float pcfDepth = texture(texSceneShadowMap, shadowPos).r;
+                shadowTerm += (shadowMapTexPos.z + bias > pcfDepth) ? 0.0 : 1.0;
+            }
+        }
+        shadowTerm /= 9.0;
+    #else
+        highp float pcfDepth = texture(texSceneShadowMap, shadowMapTexPos.xy).r;
+        shadowTerm = (shadowMapTexPos.z + bias > pcfDepth) ? 0.0 : 1.0;
+    #endif
+
+    #if defined (CLOUD_SHADOWS) && !defined (VOLUMETRIC_LIGHTING)
+        // TODO: Add shader parameters for this...
+        // Get the preconfigured value from the randomized texture, sampling a value from it to determine how much cloud shadow there will be.
+        // Clamp the value so that clouds do not turn the surface black.
+        float cloudOcclusion = clamp(texture2D(texSceneClouds, (worldPosition.xz + cameraPosition.xz) * 0.005 + timeToTick(time, 0.002)).r * 10,0.6,1);
+
+        // Combine the cloud shadow with the dynamic shadows
+        shadowTerm *= rescaleRange(cloudOcclusion,0,1,0,shadowTerm);
+    #endif
+#endif
+
+
+
+    vec3 eyeVec = -normalize(viewSpacePos.xyz).xyz;
+
+    float lightDist = length(lightDir);
+    vec3 lightDirNorm = lightDir / lightDist;
+
+    float ambTerm = lightAmbientIntensity;
+    float lambTerm = clamp(max(0.0, dot(normal, lightDirNorm)), 0, 1);
+
+    // Apply "back light"
+    // TODO: Make intensity a shader parameter
+    const float backLightIntens = 0.5;
+    lambTerm += max(0.0, dot(normal, -lightDirNorm)) * backLightIntens;
+
+    float specTerm  = calcSpecLightNormalized(normal, lightDirNorm, eyeVec, lightSpecularPower);
+
+#if defined (DYNAMIC_SHADOWS) && defined (FEATURE_LIGHT_DIRECTIONAL)
+    // ensure that the shadow does not make the surface completely black
+    shadowTerm = clamp(shadowTerm, 0.5, 1.0);
+
+    lambTerm *= shadowTerm;
+    specTerm *= shadowTerm;
+    // TODO: Add this as a shader parameter...
+    ambTerm *= shadowTerm;
+#endif
+
+    float specular = shininess * specTerm;
+
+#if defined (FEATURE_LIGHT_POINT)
+    vec3 color = ambTerm * lightColorAmbient;
+    color *= lightColorDiffuse * lightDiffuseIntensity * lambTerm;
+#elif defined (FEATURE_LIGHT_DIRECTIONAL)
+    vec4 lightBuffer = texture2D(texSceneOpaqueLightBuffer, projectedPos.xy);
+    float sunlightIntensity = lightBuffer.y;
+    vec3 color = calcSunlightColorDeferred(sunlightIntensity, lambTerm, ambTerm, lightDiffuseIntensity, lightColorAmbient, lightColorDiffuse);
+#else
+    vec3 color = vec3(1.0, 0.0, 1.0);
+#endif
+
+#if defined (FEATURE_LIGHT_POINT)
+
+    // calculate basic attenuation
+    // realistic attenuation ref: https://imdoingitwrong.wordpress.com/2011/01/31/light-attenuation/
+    float denom = lightDist/lightAttenuationRange + 1;
+    float attenuation = 1.0/(denom*denom);
+
+    // Force the light to gradually come to a complete stop at the attenuation range + falloff distance.
+    float lightDistPastRange = max(lightDist - lightAttenuationRange, 0.0);
+    float falloffTerm = 1.0 - min(lightDistPastRange / lightAttenuationFalloff, 1.0);
+    attenuation *= falloffTerm;
+
+    attenuation = max(attenuation,0);
+
+    specular *= attenuation * max(dot(lightDir/ lightDist, normal), 0);
+    color *= attenuation * max(dot(lightDir/ lightDist, normal), 0);
+#endif
+
+// TODO A 3D wizard should take a look at this. Configurable for the moment to make better comparisons possible.
+#if defined (CLAMP_LIGHTING)
+    gl_FragData[0].rgba = clamp(vec4(color.r, color.g, color.b, specular), 0.0, 1.0);
+#else
+    gl_FragData[0].rgba = vec4(color.r, color.g, color.b, specular);
+#endif
+
+}

--- a/assets/shaders/lightGeometryPass_vert.glsl
+++ b/assets/shaders/lightGeometryPass_vert.glsl
@@ -1,0 +1,25 @@
+#version 330 core
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+layout (location = 0) in vec3 in_vert;
+layout (location = 1) in vec3 in_normal;
+layout (location = 2) in vec2 in_uv0;
+layout (location = 4) in vec4 in_color0;
+
+out vec2 v_uv0;
+out vec4 v_vertexProjPos;
+
+uniform mat4 modelMatrix;
+uniform mat4 viewProjMatrix;
+
+void main() {
+#if defined (FEATURE_LIGHT_POINT)
+    v_vertexProjPos = (viewProjMatrix * modelMatrix) * vec4(in_vert, 1.0);
+#elif defined (FEATURE_LIGHT_DIRECTIONAL)
+    v_vertexProjPos = vec4(in_vert, 1.0);
+#endif
+
+    gl_Position = v_vertexProjPos;
+    v_uv0 = in_uv0;
+}

--- a/assets/shaders/lightShafts_frag.glsl
+++ b/assets/shaders/lightShafts_frag.glsl
@@ -1,0 +1,44 @@
+#version 330 core
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+in vec2 v_uv0;
+
+uniform float weight;
+uniform float decay;
+uniform float exposure;
+uniform float density;
+
+uniform sampler2D texScene;
+
+uniform float lightDirDotViewDir;
+uniform vec2 lightScreenPos;
+
+void main() {
+    gl_FragData[0].rgba = vec4(0.0, 0.0, 0.0, 1.0);
+
+    if (lightDirDotViewDir > 0.0) {
+        vec2 uv0 = v_uv0;
+        vec2 deltaTexCoord = (1.0 / float(LIGHT_SHAFT_SAMPLES)) * density * vec2(uv0.xy - lightScreenPos.xy);
+
+        float dist = length(deltaTexCoord.xy);
+
+        // TODO: This shouldn't be hardcoded
+        float threshold = 0.01;
+        if (dist > threshold) {
+            deltaTexCoord.xy /= (dist / threshold);
+        }
+
+        float illuminationDecay = 1.0;
+        for(int i=0; i < LIGHT_SHAFT_SAMPLES; i++) {
+            uv0 -= deltaTexCoord;
+            vec3 sampler = texture(texScene, uv0).rgb;
+
+            sampler *= illuminationDecay * weight;
+            gl_FragData[0].rgb += sampler;
+            illuminationDecay *= decay;
+        }
+
+        gl_FragData[0].rgb *= exposure * lightDirDotViewDir;
+    }
+}

--- a/assets/shaders/lightShafts_vert.glsl
+++ b/assets/shaders/lightShafts_vert.glsl
@@ -1,0 +1,15 @@
+#version 330 core
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+layout (location = 0) in vec3 in_vert;
+layout (location = 1) in vec3 in_normal;
+layout (location = 2) in vec2 in_uv0;
+layout (location = 4) in vec4 in_color0;
+
+out vec2 v_uv0;
+
+void main() {
+    gl_Position = vec4(in_vert, 1.0);
+    v_uv0 = in_uv0;
+}

--- a/assets/shaders/outputPass_frag.glsl
+++ b/assets/shaders/outputPass_frag.glsl
@@ -1,0 +1,19 @@
+#version 330 core
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+in vec2 v_uv0;
+
+uniform sampler2D target;
+
+void main() {
+    vec4 diffColor = texture(target, v_uv0.xy);
+
+    #if defined (FEATURE_ALPHA_REJECT)
+    if (diffColor.a < 0.1) {
+        discard;
+    }
+    #endif
+
+    gl_FragData[0].rgba = diffColor;
+}

--- a/assets/shaders/outputPass_vert.glsl
+++ b/assets/shaders/outputPass_vert.glsl
@@ -1,0 +1,14 @@
+#version 330 core
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+layout (location = 0) in vec3 in_vert;
+layout (location = 1) in vec3 in_normal;
+layout (location = 2) in vec2 in_uv0;
+layout (location = 4) in vec4 in_color0;
+
+out vec2 v_uv0;
+
+void main() {
+    gl_Position = vec4(in_vert, 1.0);
+    v_uv0 = in_uv0;
+}

--- a/assets/shaders/post_frag.glsl
+++ b/assets/shaders/post_frag.glsl
@@ -1,0 +1,116 @@
+#version 330 core
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+in vec2 v_uv0;
+
+uniform sampler2D texScene;
+uniform sampler2D texDepth;
+
+uniform sampler3D texColorGradingLut;
+
+#if !defined (NO_BLUR)
+uniform sampler2D texBlur;
+uniform float focalDistance;//distance from the camera to object at the center of the screen
+#endif
+
+#ifdef FILM_GRAIN
+uniform sampler2D texNoise;
+
+uniform vec2 noiseSize;
+uniform vec2 renderTargetSize;
+
+uniform float noiseOffset;
+uniform float grainIntensity;
+#endif
+
+#ifdef MOTION_BLUR
+uniform mat4 invViewProjMatrix;
+uniform mat4 prevViewProjMatrix;
+#endif
+
+void main() {
+#if !defined (NO_BLUR)
+    vec4 colorBlur = texture(texBlur, v_uv0.xy);
+#endif
+
+    float currentDepth = texture(texDepth, v_uv0.xy).x * 2.0 - 1.0;
+//TODO: Separate the underwater shader effect from the depth of field effect - Amrit 'Who'
+/**
+ * Calculate blur for depth of field effect and underwater.
+ */
+#ifndef NO_BLUR
+    //depthLin - distance of the fragment currently being processed from the camera as a fraction of the view distance.
+    float depthLin = linDepthViewingDistance(currentDepth);
+    float blur = 0.0;
+    //nearBoundDOF - Distance from the camera to the beginning of the area where no blur will be applied as a fraction of the view distance
+    float nearBoundDOF = clamp((focalDistance - 15),0.0,focalDistance)/viewingDistance;
+    //farBoundDOF - Distance from the camera to the end of the area where no blur will be applied as a fraction of the view distance
+    float farBoundDOF = clamp((focalDistance + 15),focalDistance,viewingDistance)/viewingDistance;
+    //if the fragment is beyond the far boundary increase the blur proportional to the fragment distance from the boundary
+    if (depthLin > farBoundDOF  && !swimming)
+       blur = clamp(((depthLin - farBoundDOF)/farBoundDOF),0.0,1.0);
+    //else if the fragment is closer than the near boundary increase the blur proportional to the fragment distance from the boundary
+    else if (depthLin < nearBoundDOF  && !swimming)
+        blur = (nearBoundDOF - depthLin)/nearBoundDOF;
+    else if (swimming) {
+       blur = 1.0;//apply full blur if underwater.
+    }
+#endif
+
+    vec4 color = texture(texScene, v_uv0.xy);
+
+#if defined (MOTION_BLUR)
+    vec4 screenSpaceNorm = vec4(v_uv0.x, v_uv0.y, currentDepth, 1.0);
+    vec4 screenSpacePos = screenSpaceNorm * vec4(2.0, 2.0, 1.0, 1.0) - vec4(1.0, 1.0, 0.0, 0.0);
+
+    vec4 worldSpacePos = invViewProjMatrix * screenSpacePos;
+    vec4 normWorldSpacePos = worldSpacePos / worldSpacePos.w;
+    vec4 prevScreenSpacePos = prevViewProjMatrix * normWorldSpacePos;
+    prevScreenSpacePos /= prevScreenSpacePos.w;
+
+    vec2 velocity = (screenSpacePos.xy - prevScreenSpacePos.xy) / 128.0;
+    velocity = clamp(velocity, vec2(-0.01), vec2(0.01));
+
+    vec2 blurTexCoord = v_uv0.xy;
+    blurTexCoord += velocity;
+    for(int i = 1; i < MOTION_BLUR_SAMPLES; ++i, blurTexCoord += velocity)
+    {
+      vec4 currentColor = texture(texScene, blurTexCoord);
+#ifndef NO_BLUR
+      vec4 currentColorBlur = texture(texBlur, blurTexCoord);
+#endif
+
+      color += currentColor;
+#ifndef NO_BLUR
+      colorBlur += currentColorBlur;
+#endif
+    }
+
+    color /= MOTION_BLUR_SAMPLES;
+#ifndef NO_BLUR
+    colorBlur /= MOTION_BLUR_SAMPLES;
+#endif
+#endif
+
+#ifndef NO_BLUR
+    vec4 finalColor = mix(color, colorBlur, blur);
+#else
+    vec4 finalColor = color;
+#endif
+
+#ifdef FILM_GRAIN
+    vec3 noise = texture(texNoise, renderTargetSize * (v_uv0.xy + noiseOffset) / noiseSize).xyz * 2.0 - 1.0;
+    finalColor.rgb += clamp(noise.xxx * grainIntensity, 0.0, 1.0);
+#endif
+
+    // In the case the color is > 1.0 or < 0.0 despite tonemapping
+    finalColor.rgb = clamp(finalColor.rgb, 0.0, 1.0);
+    vec3 lutScale = vec3(15.0 / 16.0);
+
+    // Color grading
+    vec3 lutOffset = vec3(1.0 / 32.0);
+    finalColor.rgb = texture(texColorGradingLut, lutScale * finalColor.rgb + lutOffset).rgb;
+
+    gl_FragData[0].rgba = finalColor;
+}

--- a/assets/shaders/post_vert.glsl
+++ b/assets/shaders/post_vert.glsl
@@ -1,0 +1,16 @@
+#version 330 core
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+layout (location = 0) in vec3 in_vert;
+layout (location = 1) in vec3 in_normal;
+layout (location = 2) in vec2 in_uv0;
+layout (location = 4) in vec4 in_color0;
+
+
+out vec2 v_uv0;
+
+void main() {
+	gl_Position = vec4(in_vert, 1.0);
+    v_uv0 = in_uv0;
+}

--- a/assets/shaders/prePostComposite_frag.glsl
+++ b/assets/shaders/prePostComposite_frag.glsl
@@ -1,0 +1,171 @@
+#version 330 core
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+in vec2 v_uv0;
+
+uniform sampler2D texSceneOpaque;
+uniform sampler2D texSceneOpaqueDepth;
+uniform sampler2D texSceneOpaqueNormals;
+uniform sampler2D texSceneOpaqueLightBuffer;
+uniform sampler2D texSceneReflectiveRefractive;
+
+#if defined (LOCAL_REFLECTIONS)
+uniform sampler2D texSceneReflectiveRefractiveNormals;
+
+uniform mat4 invProjMatrix;
+uniform mat4 projMatrix;
+#endif
+
+#ifdef INSCATTERING
+uniform vec4 skyInscatteringSettingsFrag;
+#define skyInscatteringStrength skyInscatteringSettingsFrag.y
+#define skyInscatteringLength skyInscatteringSettingsFrag.z
+#define skyInscatteringThreshold skyInscatteringSettingsFrag.w
+
+uniform sampler2D texSceneSkyBand;
+#endif
+
+#ifdef SSAO
+uniform sampler2D texSsao;
+#endif
+#ifdef OUTLINE
+uniform sampler2D texEdges;
+
+uniform float outlineDepthThreshold;
+uniform float outlineThickness;
+
+#define OUTLINE_COLOR 0.0, 0.0, 0.0
+#endif
+
+#ifdef VOLUMETRIC_FOG
+#define VOLUMETRIC_FOG_COLOR 1.0, 1.0, 1.0
+
+uniform mat4 invViewProjMatrix;
+uniform vec3 volumetricFogSettings;
+#define volFogDensityAtViewer volumetricFogSettings.x
+#define volFogGlobalDensity volumetricFogSettings.y
+#define volFogHeightFalloff volumetricFogSettings.z
+
+uniform vec3 fogWorldPosition;
+#endif
+
+void main() {
+    vec4 colorOpaque = texture(texSceneOpaque, v_uv0.xy);
+    float depthOpaque = texture(texSceneOpaqueDepth, v_uv0.xy).r * 2.0 - 1.0;
+    vec4 normalOpaque = texture(texSceneOpaqueNormals, v_uv0.xy);
+    vec4 colorTransparent = texture(texSceneReflectiveRefractive, v_uv0.xy);
+    vec4 lightBufferOpaque = texture(texSceneOpaqueLightBuffer, v_uv0.xy);
+
+#if defined VOLUMETRIC_FOG
+    // TODO: As costly as in the deferred light geometry pass - frustum ray method would be great here
+    vec3 fragmentPositionInCameraSpace = reconstructViewPos(depthOpaque, v_uv0.xy, invViewProjMatrix);
+#endif
+
+#if defined (LOCAL_REFLECTIONS)
+    vec3 worldPositionViewSpace = reconstructViewPos(depthOpaque, v_uv0.xy, invProjMatrix);
+
+    vec4 transparentNormalColorValue = texture(texSceneReflectiveRefractiveNormals, v_uv0.xy).xyzw;
+    vec3 reflectionNormal = transparentNormalColorValue.xyz * 2.0 - 1.0;
+    vec3 viewingDirection = normalize(worldPositionViewSpace.xyz);
+
+    vec3 reflectionDirection = reflect(viewingDirection.xyz, reflectionNormal.xyz);
+
+    // TODO: Move this some place else
+#define SAMPLES_LOCAL_REFLECTION 64
+#define RAY_MARCHING_DISTANCE 128.0
+#define SAMPLE_STEP_SIZE (RAY_MARCHING_DISTANCE / SAMPLES_LOCAL_REFLECTION)
+#define ANGLE_THRESHOLD 0.5
+#define ANGLE_FADE_INTERVAL 0.1
+#define EDGE_THRESHOLD 0.95
+#define EDGE_FADE_INTERVAL 0.05
+
+    vec3 viewSpaceRayPosition = worldPositionViewSpace;
+    for (int i=0; i<SAMPLES_LOCAL_REFLECTION; ++i) {
+        viewSpaceRayPosition += reflectionDirection * SAMPLE_STEP_SIZE;
+
+        vec4 screenSpaceRayPosition = projMatrix * vec4(viewSpaceRayPosition.x, viewSpaceRayPosition.y, viewSpaceRayPosition.z, 1.0);
+        screenSpaceRayPosition.xyz /= screenSpaceRayPosition.w;
+
+        // Nahh... We don't want to touch anything outside of the screen
+        // TODO: Maybe fade at the screen edges?
+        if (abs(screenSpaceRayPosition.x) > 1.0 || abs(screenSpaceRayPosition.y) > 1.0) {
+            break;
+        }
+
+        float newSampledDepth = texture(texSceneOpaqueDepth, screenSpaceRayPosition.xy * 0.5 + 0.5).r * 2.0 - 1.0;
+
+        if (newSampledDepth < screenSpaceRayPosition.z) {
+            float reflectionFadeFactor = transparentNormalColorValue.a;
+
+            // TODO: Make this an option
+            // Fades the reflection if the reflection vector is too steep
+            if (reflectionDirection.y > ANGLE_THRESHOLD) {
+                reflectionFadeFactor *= clamp(1.0 - (reflectionDirection.y - ANGLE_THRESHOLD) / ANGLE_FADE_INTERVAL, 0.0, 1.0);
+            }
+
+            // Fade out at the edges
+            // TODO: Make this an option
+            float rayLength = length(screenSpaceRayPosition.xy);
+            if (rayLength > EDGE_THRESHOLD) {
+                reflectionFadeFactor *= clamp(1.0 - (rayLength - EDGE_THRESHOLD) / EDGE_FADE_INTERVAL, 0.0, 1.0);
+            }
+
+            // TODO: Find a better way to do this... Using the previous frame buffer caused too much lag though
+            vec4 tempColTransparent = texture(texSceneReflectiveRefractive, screenSpaceRayPosition.xy * 0.5 + 0.5).rgba;
+            vec3 tempColOpaque = texture(texSceneOpaque, screenSpaceRayPosition.xy * 0.5 + 0.5).rgb;
+
+            float fade = clamp(1.0 - tempColTransparent.a, 0.0, 1.0);
+            vec3 reflectionColor = mix(tempColTransparent.rgb, tempColOpaque.rgb, fade);
+            colorTransparent.rgb = mix(colorTransparent.rgb, reflectionColor, reflectionFadeFactor);
+            break;
+        }
+    }
+#endif
+
+#ifdef SSAO
+    float ssao = texture(texSsao, v_uv0.xy).x;
+    colorOpaque.rgb *= ssao;
+#endif
+
+#ifdef OUTLINE
+    vec3 screenSpaceNormal = normalOpaque.xyz * 2.0 - 1.0;
+    float outlineFadeFactor = (1.0 - abs(screenSpaceNormal.y)); // Use the normal to avoid artifacts on flat wide surfaces
+
+    float outline = step(outlineDepthThreshold, texture(texEdges, v_uv0.xy).x) * outlineThickness * outlineFadeFactor;
+    colorOpaque.rgb = mix(colorOpaque.rgb, vec3(OUTLINE_COLOR), outline);
+#endif
+
+#ifdef INSCATTERING
+    // No scattering in the sky please - otherwise we end up with an ugly blurry sky
+    if (!epsilonEqualsOne(depthOpaque)) {
+        // Sky inscattering using down-sampled sky band texture
+        vec3 skyInscatteringColor = texture(texSceneSkyBand, v_uv0.xy).rgb;
+
+        float d = abs(linDepthViewingDistance(depthOpaque));
+
+        float fogValue = clamp((1.0 - (skyInscatteringLength - d) / clamp(skyInscatteringLength - skyInscatteringThreshold, 0.0, 1.0)) * skyInscatteringStrength, 0.0, 1.0);
+
+        colorOpaque.rgb = mix(colorOpaque.rgb, skyInscatteringColor, fogValue);
+        colorTransparent.rgb = mix(colorTransparent.rgb, skyInscatteringColor, fogValue);
+    }
+#endif
+
+#ifdef VOLUMETRIC_FOG
+    // Use lightValueAtPlayerPos to avoid volumetric fog in caves
+    float volumetricFogValue = calcVolumetricFog(fragmentPositionInCameraSpace - fogWorldPosition, volFogDensityAtViewer, volFogGlobalDensity, volFogHeightFalloff);
+
+    vec3 volFogColor = vec3(VOLUMETRIC_FOG_COLOR);
+
+    colorOpaque.rgb = mix(colorOpaque.rgb, volFogColor, volumetricFogValue);
+    colorTransparent.rgb = mix(colorTransparent.rgb, volFogColor, volumetricFogValue);
+#endif
+
+    float fade = clamp(1.0 - colorTransparent.a, 0.0, 1.0);
+    vec4 color = mix(colorTransparent, colorOpaque, fade);
+
+    gl_FragData[0].rgba = color.rgba;
+    gl_FragData[1].rgba = normalOpaque.rgba;
+    gl_FragData[2].rgba = lightBufferOpaque.rgba;
+    gl_FragDepth = depthOpaque * 0.5 + 0.5;
+}

--- a/assets/shaders/prePostComposite_vert.glsl
+++ b/assets/shaders/prePostComposite_vert.glsl
@@ -1,0 +1,14 @@
+#version 330 core
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+layout (location = 0) in vec3 in_vert;
+layout (location = 1) in vec3 in_normal;
+layout (location = 2) in vec2 in_uv0;
+layout (location = 4) in vec4 in_color0;
+
+out vec2 v_uv0;
+
+void main() {
+    gl_Position = vec4(in_vert, 1.0);
+    v_uv0 = in_uv0;
+}

--- a/assets/shaders/shadowMap_frag.glsl
+++ b/assets/shaders/shadowMap_frag.glsl
@@ -1,0 +1,6 @@
+#version 330 core
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+void main() {
+}

--- a/assets/shaders/shadowMap_vert.glsl
+++ b/assets/shaders/shadowMap_vert.glsl
@@ -1,0 +1,15 @@
+#version 330 core
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+layout (location = 0) in vec3 in_vert;
+
+uniform mat4 modelViewMatrix;
+uniform mat4 projectionMatrix;
+
+//out vec4 v_pos;
+
+void main() {
+	gl_Position = projectionMatrix * modelViewMatrix *  vec4(in_vert, 1.0);
+
+}

--- a/assets/shaders/sky_frag.glsl
+++ b/assets/shaders/sky_frag.glsl
@@ -1,0 +1,65 @@
+#version 330 core
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+in vec4 v_position;
+in vec2 v_uv0;
+in vec3 v_colorYxy;
+in vec3 v_skyVec;
+
+uniform sampler2D texSky180;
+uniform sampler2D texSky90;
+
+uniform float colorExp;
+uniform vec3 zenith;
+
+uniform vec4 skySettings;
+#define sunExponent skySettings.x
+#define moonExponent skySettings.y
+
+#define skyDaylightBrightness skySettings.z
+#define skyNightBrightness skySettings.w
+
+const vec4 eyePos = vec4(0.0, 0.0, 0.0, 1.0);
+
+#define HIGHLIGHT_BLEND_START 0.1
+#define SUN_HIGHLIGHT_INTENSITY_FACTOR 1.0
+#define MOON_HIGHLIGHT_INTENSITY_FACTOR 1.0
+
+void main () {
+    vec3 v = normalize(v_position.xyz);
+    vec3 l = normalize(sunVec.xyz);
+
+    float lDotV = dot(l, v);
+    float negLDotV = dot(-l, v);
+
+    float sunHighlight = 0.0;
+    if (lDotV >= 0.0 && l.y >= 0.0) {
+       sunHighlight = pow(lDotV, sunExponent) * SUN_HIGHLIGHT_INTENSITY_FACTOR;
+    }
+    if (l.y < HIGHLIGHT_BLEND_START && l.y >= 0.0) {
+       sunHighlight *= 1.0 - (HIGHLIGHT_BLEND_START - l.y) / HIGHLIGHT_BLEND_START;
+    }
+
+    float moonHighlight = 0.0;
+    if (negLDotV >= 0.0 && -l.y >= 0.0) {
+       moonHighlight = pow(negLDotV, moonExponent) * MOON_HIGHLIGHT_INTENSITY_FACTOR;
+    }
+    if (-l.y < HIGHLIGHT_BLEND_START && -l.y >= 0.0) {
+       moonHighlight *= 1.0 - (HIGHLIGHT_BLEND_START + l.y) / HIGHLIGHT_BLEND_START;
+    }
+
+    vec4 skyColor = vec4(0.0, 0.0, 0.0, 1.0);
+
+    /* PROCEDURAL SKY COLOR */
+    vec4 cloudsColor = texture(texSky180, v_uv0.xy);
+    vec4 cloudsColorNight = texture(texSky90, v_uv0.xy);
+
+    /* DAY AND NIGHT TEXTURES */
+    skyColor.rgb = skyDaylightBrightness * daylight * cloudsColor.rgb + (1.0 - daylight) * skyNightBrightness * cloudsColorNight.rgb;
+    skyColor.rgb *= mix(convertColorYxy(v_colorYxy, colorExp).rgb, vec3(1.0, 1.0, 1.0), 1.0 - daylight);
+
+    skyColor.rgb += vec3((1.0 - cloudsColor.r) * sunHighlight + (1.0 - cloudsColor.r) * moonHighlight);
+
+    gl_FragData[0].rgba = skyColor.rgba;
+}

--- a/assets/shaders/sky_vert.glsl
+++ b/assets/shaders/sky_vert.glsl
@@ -1,0 +1,70 @@
+#version 330 core
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+layout (location = 0) in vec3 in_vert;
+layout (location = 1) in vec3 in_normal;
+layout (location = 2) in vec2 in_uv0;
+layout (location = 4) in vec4 in_color0;
+
+out	vec4 v_position;
+out vec2 v_uv0;
+out	vec3 v_colorYxy;
+out vec3 v_skyVec;
+
+uniform float	sunAngle;
+uniform	float	turbidity;
+uniform vec3    zenith;
+
+const vec4 eyePos = vec4(0.0, 0.0, 0.0, 1.0);
+
+uniform mat4 modelViewMatrix;
+uniform mat4 projectionMatrix;
+
+vec3 allWeather(float t, float cosTheta, float cosGamma) {
+    float   gamma      = acos ( cosGamma );
+    float   cosGammaSq = cosGamma * cosGamma;
+    float   aY =  0.17872 * t - 1.46303;
+    float   bY = -0.35540 * t + 0.42749;
+    float   cY = -0.02266 * t + 5.32505;
+    float   dY =  0.12064 * t - 2.57705;
+    float   eY = -0.06696 * t + 0.37027;
+    float   ax = -0.01925 * t - 0.25922;
+    float   bx = -0.06651 * t + 0.00081;
+    float   cx = -0.00041 * t + 0.21247;
+    float   dx = -0.06409 * t - 0.89887;
+    float   ex = -0.00325 * t + 0.04517;
+    float   ay = -0.01669 * t - 0.26078;
+    float   by = -0.09495 * t + 0.00921;
+    float   cy = -0.00792 * t + 0.21023;
+    float   dy = -0.04405 * t - 1.65369;
+    float   ey = -0.01092 * t + 0.05291;
+
+    return vec3 ((1.0 + aY * exp(bY/cosTheta)) * (1.0 + cY * exp(dY * gamma) + eY*cosGammaSq),
+                  (1.0 + ax * exp(bx/cosTheta)) * (1.0 + cx * exp(dx * gamma) + ex*cosGammaSq),
+                  (1.0 + ay * exp(by/cosTheta)) * (1.0 + cy * exp(dy * gamma) + ey*cosGammaSq));
+}
+
+vec3 allWeatherSky(float t, float cosTheta, float cosGamma, float cosThetaSun) {
+  float	thetaSun = acos(cosThetaSun);
+
+  vec3	clrYxy = zenith * allWeather(t, cosTheta, cosGamma) / allWeather (t, 1.0, cosThetaSun);
+  clrYxy.x *= smoothstep ( 0.0, 0.1, cosThetaSun );
+
+  return clrYxy;
+}
+
+void main(void) {
+    float   sa  = sin (sunAngle);
+    float   ca  = cos (sunAngle);
+    mat3    r   = mat3 (1.0, 0.0, 0.0, 0.0, ca, -sa, 0.0, sa, ca);
+
+    vec3 v          = normalize ((vec4(in_vert, 1.0) - eyePos).xyz);
+    vec3 l          = sunVec;
+    float lv        = dot(l, v);
+    v_skyVec        = v.xyz;
+    v_colorYxy      = allWeatherSky(turbidity, max(v.y, 0.0) + 0.05, lv, l.y);
+    v_position      = vec4(in_vert, 1.0);
+    v_uv0           = in_uv0;
+    gl_Position     = (projectionMatrix * modelViewMatrix) * v_position;
+}

--- a/assets/shaders/sobel_frag.glsl
+++ b/assets/shaders/sobel_frag.glsl
@@ -1,0 +1,36 @@
+#version 330 core
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+in vec2 v_uv0;
+
+uniform sampler2D texDepth;
+
+uniform float texelWidth;
+uniform float texelHeight;
+
+uniform float pixelOffsetX;
+uniform float pixelOffsetY;
+
+float fetchDepth(float x, float y) {
+    return linDepth(texture2D(texDepth, v_uv0.xy + vec2(x*texelWidth*pixelOffsetX, y*texelHeight*pixelOffsetY)).x);
+}
+
+void main() {
+    mat3 depthMatrix;
+    depthMatrix[0][0] = fetchDepth(-1.0, -1.0);
+    depthMatrix[1][0] = fetchDepth(0.0, -1.0);
+    depthMatrix[2][0] = fetchDepth(1.0, -1.0);
+    depthMatrix[0][1] = fetchDepth(-1.0, 0.0);
+    depthMatrix[2][1] = fetchDepth(1.0, 0.0);
+    depthMatrix[0][2] = fetchDepth(-1.0, 1.0);
+    depthMatrix[1][2] = fetchDepth(0.0, 1.0);
+    depthMatrix[2][2] = fetchDepth(1.0, 1.0);
+
+    float gx, gy;
+    gx = -1.0*depthMatrix[0][0]-2.0*depthMatrix[1][0]-1.0*depthMatrix[2][0]+1.0*depthMatrix[0][2]+2.0*depthMatrix[1][2]+1.0*depthMatrix[2][2];
+    gy = -1.0*depthMatrix[0][0]-2.0*depthMatrix[0][1]-1.0*depthMatrix[0][2]+1.0*depthMatrix[2][0]+2.0*depthMatrix[2][1]+1.0*depthMatrix[2][2];
+
+    float result = sqrt(gx*gx + gy*gy);
+    gl_FragData[0].rgba = vec4(result, result, result, 1.0);
+}

--- a/assets/shaders/sobel_vert.glsl
+++ b/assets/shaders/sobel_vert.glsl
@@ -1,0 +1,15 @@
+#version 330 core
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+layout (location = 0) in vec3 in_vert;
+layout (location = 1) in vec3 in_normal;
+layout (location = 2) in vec2 in_uv0;
+layout (location = 4) in vec4 in_color0;
+
+out vec2 v_uv0;
+
+void main() {
+    gl_Position = vec4(in_vert, 1.0);
+    v_uv0 = in_uv0;
+}

--- a/assets/shaders/ssaoBlur_frag.glsl
+++ b/assets/shaders/ssaoBlur_frag.glsl
@@ -1,0 +1,20 @@
+#version 330 core
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+uniform sampler2D tex;
+uniform vec2 texelSize;
+
+in vec2 v_uv0;
+
+void main() {
+    float result = 0.0;
+    for (int i=-2; i<2; ++i) {
+        for (int j=-2; j<2; ++j) {
+            vec2 offset = vec2(texelSize.x * float(j), texelSize.y * float(i));
+            result += texture(tex, v_uv0.xy + offset).r;
+        }
+    }
+
+    gl_FragData[0].rgba = vec4(result / 16.0);
+}

--- a/assets/shaders/ssaoBlur_vert.glsl
+++ b/assets/shaders/ssaoBlur_vert.glsl
@@ -1,0 +1,15 @@
+#version 330 core
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+layout (location = 0) in vec3 in_vert;
+layout (location = 1) in vec3 in_normal;
+layout (location = 2) in vec2 in_uv0;
+layout (location = 4) in vec4 in_color0;
+
+out vec2 v_uv0;
+
+void main() {
+    gl_Position = vec4(in_vert, 1.0);
+    v_uv0 = in_uv0;
+}

--- a/assets/shaders/ssao_frag.glsl
+++ b/assets/shaders/ssao_frag.glsl
@@ -1,0 +1,79 @@
+#version 330 core
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+in vec2 v_uv0;
+
+uniform vec4 ssaoSettings;
+#define ssaoStrength ssaoSettings.x
+#define ssaoRadius ssaoSettings.y
+
+uniform vec2 texelSize;
+uniform vec2 noiseTexelSize;
+
+uniform sampler2D texNormals;
+uniform sampler2D texNoise;
+uniform sampler2D texDepth;
+
+uniform mat4 invProjMatrix;
+uniform mat4 projMatrix;
+
+uniform vec3 ssaoSamples[SSAO_KERNEL_ELEMENTS];
+
+void main() {
+    float currentDepth = texture2D(texDepth, v_uv0.xy).x * 2.0 - 1.0;
+
+    // Exclude the sky...
+    if (epsilonEqualsOne(currentDepth)) {
+        gl_FragData[0].rgba = vec4(1.0);
+        return;
+    }
+
+    vec3 normal = texture2D(texNormals, v_uv0.xy).xyz * 2.0 - 1.0;
+
+    vec2 noiseScale = noiseTexelSize / texelSize;
+    vec3 randomVec = texture(texNoise, v_uv0.xy * noiseScale).xyz * 2.0 - 1.0;
+
+    // TODO: This is costly... See below
+    vec3 viewSpacePos = reconstructViewPos(currentDepth, v_uv0.xy, invProjMatrix);
+
+    vec3 tangent = normalize(randomVec - normal * dot(randomVec, normal));
+    vec3 bitangent = cross(normal, tangent);
+    mat3 tbn = mat3(tangent, bitangent, normal);
+
+    float occlusion = 0.0;
+    float sampleDepth = 0.0;
+    float rangeCheck = 0.0;
+    vec3 samplePosition = vec3(0.0);
+    vec4 offset = vec4(0.0);
+    float samplesTaken = 0.0;
+    const float maxDepthDifference = 1;
+
+    for (int i=0; i<SSAO_KERNEL_ELEMENTS; ++i) {
+        samplePosition = (tbn * ssaoSamples[i]) * ssaoRadius + viewSpacePos;
+
+        offset = vec4(samplePosition.x, samplePosition.y, samplePosition.z, 1.0);
+        offset = projMatrix * offset;
+        offset.xy /= offset.w;
+        offset.xy = offset.xy * vec2(0.5) + vec2(0.5);
+
+        // TODO: Holy... frustum ray and linearized depth - please!
+        sampleDepth = reconstructViewPos(texture2D(texDepth, offset.xy).r * 2.0 - 1.0, v_uv0.xy, invProjMatrix).z;
+        float depthDifference = abs(viewSpacePos.z - sampleDepth);
+
+        float rangeCheck;
+        if (depthDifference > maxDepthDifference) {
+        	rangeCheck = 0;
+        } else {
+        	rangeCheck = smoothstep(0.0, 1.0, ssaoRadius / depthDifference);
+        }
+
+        occlusion += step(samplePosition.z, sampleDepth) * rangeCheck;
+
+        samplesTaken += 1.0;
+    }
+
+    occlusion = 1.0 - occlusion / samplesTaken;
+
+    gl_FragData[0].rgba = vec4(pow(occlusion, ssaoStrength));
+}

--- a/assets/shaders/ssao_vert.glsl
+++ b/assets/shaders/ssao_vert.glsl
@@ -1,0 +1,15 @@
+#version 330 core
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+layout (location = 0) in vec3 in_vert;
+layout (location = 1) in vec3 in_normal;
+layout (location = 2) in vec2 in_uv0;
+layout (location = 4) in vec4 in_color0;
+
+out vec2 v_uv0;
+
+void main() {
+    gl_Position = vec4(in_vert, 1.0);
+    v_uv0 = in_uv0;
+}

--- a/assets/shaders/toneMapping_frag.glsl
+++ b/assets/shaders/toneMapping_frag.glsl
@@ -1,0 +1,38 @@
+#version 330 core
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+#define UNCHARTED_2_TONEMAP
+// #define REINHARD_TONEMAP
+// #define BURGESS_TONEMAP
+
+
+in vec2 v_uv0;
+
+uniform sampler2D texScene;
+uniform float exposure = 1;
+uniform float whitePoint = W;
+
+void main(){
+    vec4 color = srgbToLinear(texture(texScene, v_uv0.xy));
+
+#ifdef REINHARD_TONEMAP
+    float t = tonemapReinhard(2.5, exposure);
+    color *= t;
+#endif
+
+#ifdef UNCHARTED_2_TONEMAP
+    //HDR tone mapping using Uncharted 2 method
+    // http://frictionalgames.blogspot.com/2012/09/tech-feature-hdr-lightning.html
+    color.rgb = uncharted2Tonemap(color.rgb * exposure) / uncharted2Tonemap(vec3(whitePoint));
+#endif
+
+#ifdef BURGESS_TONEMAP
+    color.rgb *= exposure;
+    vec3 x = max(vec3(0.0),color.rgb-vec3(0.004));
+    vec3 finalColor = (x*(6.2*x+.5))/(x*(6.2*x+1.7)+0.06);
+    color.rgb = finalColor;
+#endif
+
+    gl_FragData[0].rgba = linearToSrgb(color);
+}

--- a/assets/shaders/toneMapping_vert.glsl
+++ b/assets/shaders/toneMapping_vert.glsl
@@ -1,0 +1,15 @@
+#version 330 core
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+layout (location = 0) in vec3 in_vert;
+layout (location = 1) in vec3 in_normal;
+layout (location = 2) in vec2 in_uv0;
+layout (location = 4) in vec4 in_color0;
+
+out vec2 v_uv0;
+
+void main() {
+    gl_Position = vec4(in_vert, 1.0);
+    v_uv0 = in_uv0;
+}

--- a/assets/shaders/vignette_frag.glsl
+++ b/assets/shaders/vignette_frag.glsl
@@ -1,0 +1,28 @@
+#version 330 core
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+
+in vec2 v_uv0;
+
+uniform sampler2D texScene;
+
+#ifdef VIGNETTE
+uniform sampler2D texVignette;
+uniform vec3 inLiquidTint;
+uniform vec3 tint = vec3(1.0,1.0,1.0);
+#endif
+
+void main(){
+    vec4 color = texture(texScene, v_uv0.xy);
+
+    #ifdef VIGNETTE
+        float vig = texture(texVignette, v_uv0.xy).x;
+        if (!swimming) {
+            color.rgb *= vec3(vig, vig, vig) + (1 - vig) * tint.rgb;
+        } else {
+            color.rgb *= vig * vig * vig;
+            color.rgb *= inLiquidTint;
+        }
+    #endif
+    gl_FragData[0].rgba = color.rgba;
+}

--- a/assets/shaders/vignette_vert.glsl
+++ b/assets/shaders/vignette_vert.glsl
@@ -1,0 +1,14 @@
+#version 330 core
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
+layout (location = 0) in vec3 in_vert;
+layout (location = 1) in vec3 in_normal;
+layout (location = 2) in vec2 in_uv0;
+layout (location = 4) in vec4 in_color0;
+
+out vec2 v_uv0;
+
+void main() {
+    gl_Position = vec4(in_vert, 1.0);
+    v_uv0 = in_uv0;
+}

--- a/src/main/java/org/terasology/corerendering/rendering/AdvancedRenderingModule.java
+++ b/src/main/java/org/terasology/corerendering/rendering/AdvancedRenderingModule.java
@@ -1,19 +1,5 @@
-/*
- * Copyright 2020 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.corerendering.rendering;
 
 import org.terasology.corerendering.rendering.dag.nodes.AmbientOcclusionNode;

--- a/src/main/java/org/terasology/corerendering/rendering/CoreRenderingModule.java
+++ b/src/main/java/org/terasology/corerendering/rendering/CoreRenderingModule.java
@@ -1,18 +1,5 @@
-/*
- * Copyright 2017 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.corerendering.rendering;
 
 import org.terasology.corerendering.rendering.dag.nodes.*;

--- a/src/main/java/org/terasology/corerendering/rendering/dag/nodes/AlphaRejectBlocksNode.java
+++ b/src/main/java/org/terasology/corerendering/rendering/dag/nodes/AlphaRejectBlocksNode.java
@@ -4,7 +4,6 @@ package org.terasology.corerendering.rendering.dag.nodes;
 
 import org.joml.Matrix3f;
 import org.joml.Matrix4f;
-import org.joml.Vector3f;
 import org.joml.Vector3fc;
 import org.terasology.engine.config.Config;
 import org.terasology.engine.config.RenderingConfig;
@@ -49,7 +48,7 @@ import static org.terasology.engine.rendering.primitives.ChunkMesh.RenderPhase.A
  * the color stored in the frame buffer and the resulting color overwrites the previously stored one.
  */
 public class AlphaRejectBlocksNode extends AbstractNode implements WireframeCapable, PropertyChangeListener {
-    private static final ResourceUrn CHUNK_MATERIAL_URN = new ResourceUrn("engine:prog.chunk");
+    private static final ResourceUrn CHUNK_MATERIAL_URN = new ResourceUrn("CoreRendering:chunk");
 
     private WorldRenderer worldRenderer;
     private RenderQueuesHelper renderQueues;

--- a/src/main/java/org/terasology/corerendering/rendering/dag/nodes/AmbientOcclusionNode.java
+++ b/src/main/java/org/terasology/corerendering/rendering/dag/nodes/AmbientOcclusionNode.java
@@ -63,7 +63,7 @@ public class AmbientOcclusionNode extends ConditionDependentNode {
     public static final SimpleUri SSAO_FBO_URI = new SimpleUri("engine:fbo.ssao");
     public static final int SSAO_KERNEL_ELEMENTS = 32;
     public static final int SSAO_NOISE_SIZE = 4;
-    private static final ResourceUrn SSAO_MATERIAL_URN = new ResourceUrn("engine:prog.ssao");
+    private static final ResourceUrn SSAO_MATERIAL_URN = new ResourceUrn("CoreRendering:ssao");
     private static final float NOISE_TEXEL_SIZE = 0.25f;
 
     private Material ssaoMaterial;

--- a/src/main/java/org/terasology/corerendering/rendering/dag/nodes/ApplyDeferredLightingNode.java
+++ b/src/main/java/org/terasology/corerendering/rendering/dag/nodes/ApplyDeferredLightingNode.java
@@ -30,7 +30,7 @@ import static org.terasology.engine.rendering.dag.stateChanges.SetInputTextureFr
  * This node is integral to the deferred lighting technique.
  */
 public class ApplyDeferredLightingNode extends AbstractNode {
-    private static final ResourceUrn DEFERRED_LIGHTING_MATERIAL_URN = new ResourceUrn("engine:prog.lightBufferPass");
+    private static final ResourceUrn DEFERRED_LIGHTING_MATERIAL_URN = new ResourceUrn("CoreRendering:lightBufferPass");
     private Mesh renderQuad;
 
     public ApplyDeferredLightingNode(String nodeUri, Name providingModule, Context context) {

--- a/src/main/java/org/terasology/corerendering/rendering/dag/nodes/BackdropNode.java
+++ b/src/main/java/org/terasology/corerendering/rendering/dag/nodes/BackdropNode.java
@@ -45,7 +45,7 @@ import static org.lwjgl.opengl.GL11.GL_FRONT;
  * The shader also procedurally adds a main light (sun/moon) in the form of a blurred disc.
  */
 public class BackdropNode extends AbstractNode implements WireframeCapable {
-    private static final ResourceUrn SKY_MATERIAL_URN = new ResourceUrn("engine:prog.sky");
+    private static final ResourceUrn SKY_MATERIAL_URN = new ResourceUrn("CoreRendering:sky");
     private static final int SLICES = 16;
     private static final int STACKS = 128;
     private static final int RADIUS = 1024;

--- a/src/main/java/org/terasology/corerendering/rendering/dag/nodes/BackdropReflectionNode.java
+++ b/src/main/java/org/terasology/corerendering/rendering/dag/nodes/BackdropReflectionNode.java
@@ -43,7 +43,7 @@ import static org.terasology.corerendering.rendering.dag.nodes.BackdropNode.getA
  */
 public class BackdropReflectionNode extends AbstractNode {
     public static final SimpleUri REFLECTED_FBO_URI = new SimpleUri("engine:fbo.sceneReflected");
-    private static final ResourceUrn SKY_MATERIAL_URN = new ResourceUrn("engine:prog.sky");
+    private static final ResourceUrn SKY_MATERIAL_URN = new ResourceUrn("CoreRendering:sky");
     private static final int RADIUS = 1024;
     private static final int SLICES = 16;
     private static final int STACKS = 128;

--- a/src/main/java/org/terasology/corerendering/rendering/dag/nodes/BloomBlurNode.java
+++ b/src/main/java/org/terasology/corerendering/rendering/dag/nodes/BloomBlurNode.java
@@ -1,18 +1,5 @@
-/*
- * Copyright 2017 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.corerendering.rendering.dag.nodes;
 
 import org.terasology.engine.config.Config;

--- a/src/main/java/org/terasology/corerendering/rendering/dag/nodes/BlurNode.java
+++ b/src/main/java/org/terasology/corerendering/rendering/dag/nodes/BlurNode.java
@@ -21,7 +21,7 @@ import org.terasology.engine.rendering.opengl.FBO;
  * a blurred version of it in the color buffer attached to the output FBO.
  */
 public class BlurNode extends ConditionDependentNode {
-    private static final ResourceUrn BLUR_MATERIAL_URN = new ResourceUrn("engine:prog.blur");
+    private static final ResourceUrn BLUR_MATERIAL_URN = new ResourceUrn("CoreRendering:blur");
 
     protected float blurRadius;
 

--- a/src/main/java/org/terasology/corerendering/rendering/dag/nodes/BlurredAmbientOcclusionNode.java
+++ b/src/main/java/org/terasology/corerendering/rendering/dag/nodes/BlurredAmbientOcclusionNode.java
@@ -44,7 +44,7 @@ import static org.terasology.engine.rendering.opengl.fbms.DisplayResolutionDepen
  */
 public class BlurredAmbientOcclusionNode extends ConditionDependentNode {
     public static final SimpleUri SSAO_BLURRED_FBO_URI = new SimpleUri("engine:fbo.ssaoBlurred");
-    private static final ResourceUrn SSAO_BLURRED_MATERIAL_URN = new ResourceUrn("engine:prog.ssaoBlur");
+    private static final ResourceUrn SSAO_BLURRED_MATERIAL_URN = new ResourceUrn("CoreRendering:ssaoBlur");
 
     private Material ssaoBlurredMaterial;
     private Mesh renderQuad;

--- a/src/main/java/org/terasology/corerendering/rendering/dag/nodes/BufferClearingNode.java
+++ b/src/main/java/org/terasology/corerendering/rendering/dag/nodes/BufferClearingNode.java
@@ -1,18 +1,5 @@
-/*
- * Copyright 2017 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.corerendering.rendering.dag.nodes;
 
 import org.terasology.engine.context.Context;

--- a/src/main/java/org/terasology/corerendering/rendering/dag/nodes/DeferredMainLightNode.java
+++ b/src/main/java/org/terasology/corerendering/rendering/dag/nodes/DeferredMainLightNode.java
@@ -55,7 +55,7 @@ import static org.terasology.engine.rendering.dag.stateChanges.SetInputTextureFr
  * light up the 3d scene.
  */
 public class DeferredMainLightNode extends AbstractNode {
-    private static final ResourceUrn LIGHT_GEOMETRY_MATERIAL_URN = new ResourceUrn("engine:prog.lightGeometryPass");
+    private static final ResourceUrn LIGHT_GEOMETRY_MATERIAL_URN = new ResourceUrn("CoreRendering:lightGeometryPass");
 
     private BackdropProvider backdropProvider;
     private RenderingConfig renderingConfig;

--- a/src/main/java/org/terasology/corerendering/rendering/dag/nodes/DeferredPointLightsNode.java
+++ b/src/main/java/org/terasology/corerendering/rendering/dag/nodes/DeferredPointLightsNode.java
@@ -1,18 +1,5 @@
-/*
- * Copyright 2020 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     https://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.corerendering.rendering.dag.nodes;
 
 import org.joml.Matrix4f;
@@ -66,7 +53,7 @@ import static org.terasology.engine.rendering.dag.stateChanges.SetInputTextureFr
  * content of other buffers to correctly light up the scene.
  */
 public class DeferredPointLightsNode extends AbstractNode {
-    private static final ResourceUrn LIGHT_GEOMETRY_MATERIAL_URN = new ResourceUrn("engine:prog.lightGeometryPass");
+    private static final ResourceUrn LIGHT_GEOMETRY_MATERIAL_URN = new ResourceUrn("CoreRendering:lightGeometryPass");
 
     private EntityManager entityManager;
     private RenderingConfig renderingConfig;

--- a/src/main/java/org/terasology/corerendering/rendering/dag/nodes/DownSamplerForExposureNode.java
+++ b/src/main/java/org/terasology/corerendering/rendering/dag/nodes/DownSamplerForExposureNode.java
@@ -1,18 +1,5 @@
-/*
- * Copyright 2017 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.corerendering.rendering.dag.nodes;
 
 import org.terasology.engine.config.Config;

--- a/src/main/java/org/terasology/corerendering/rendering/dag/nodes/DownSamplerNode.java
+++ b/src/main/java/org/terasology/corerendering/rendering/dag/nodes/DownSamplerNode.java
@@ -1,18 +1,5 @@
-/*
- * Copyright 2017 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.corerendering.rendering.dag.nodes;
 
 import org.terasology.engine.context.Context;
@@ -39,7 +26,7 @@ import static org.terasology.engine.rendering.dag.stateChanges.SetInputTextureFr
  */
 public class DownSamplerNode extends ConditionDependentNode {
     private static final String TEXTURE_NAME = "tex";
-    private static final ResourceUrn DOWN_SAMPLER_MATERIAL_URN = new ResourceUrn("engine:prog.downSampler");
+    private static final ResourceUrn DOWN_SAMPLER_MATERIAL_URN = new ResourceUrn("CoreRendering:downSampler");
 
     private FBO outputFbo;
     private Material downSampler;

--- a/src/main/java/org/terasology/corerendering/rendering/dag/nodes/FinalPostProcessingNode.java
+++ b/src/main/java/org/terasology/corerendering/rendering/dag/nodes/FinalPostProcessingNode.java
@@ -1,18 +1,5 @@
-/*
- * Copyright 2017 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.corerendering.rendering.dag.nodes;
 
 import org.terasology.engine.config.Config;
@@ -64,7 +51,7 @@ import static org.terasology.engine.rendering.opengl.ScalingFactors.FULL_SCALE;
  */
 public class FinalPostProcessingNode extends AbstractNode implements PropertyChangeListener {
     public static final SimpleUri POST_FBO_URI = new SimpleUri("engine:fbo.finalBuffer");
-    private static final ResourceUrn POST_MATERIAL_URN = new ResourceUrn("engine:prog.post");
+    private static final ResourceUrn POST_MATERIAL_URN = new ResourceUrn("CoreRendering:post");
 
     private WorldRenderer worldRenderer;
     private RenderingConfig renderingConfig;

--- a/src/main/java/org/terasology/corerendering/rendering/dag/nodes/HazeNode.java
+++ b/src/main/java/org/terasology/corerendering/rendering/dag/nodes/HazeNode.java
@@ -1,18 +1,5 @@
-/*
- * Copyright 2017 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.corerendering.rendering.dag.nodes;
 
 import org.terasology.engine.config.Config;

--- a/src/main/java/org/terasology/corerendering/rendering/dag/nodes/HighPassNode.java
+++ b/src/main/java/org/terasology/corerendering/rendering/dag/nodes/HighPassNode.java
@@ -33,7 +33,7 @@ import static org.terasology.engine.rendering.opengl.ScalingFactors.FULL_SCALE;
 public class HighPassNode extends ConditionDependentNode {
     public static final SimpleUri HIGH_PASS_FBO_URI = new SimpleUri("engine:fbo.highPass");
     public static final FboConfig HIGH_PASS_FBO_CONFIG = new FboConfig(HIGH_PASS_FBO_URI, FULL_SCALE, FBO.Type.DEFAULT);
-    private static final ResourceUrn HIGH_PASS_MATERIAL_URN = new ResourceUrn("engine:prog.highPass");
+    private static final ResourceUrn HIGH_PASS_MATERIAL_URN = new ResourceUrn("CoreRendering:highPass");
 
     @SuppressWarnings("FieldCanBeLocal")
     @Range(min = 0.0f, max = 5.0f)

--- a/src/main/java/org/terasology/corerendering/rendering/dag/nodes/InitialPostProcessingNode.java
+++ b/src/main/java/org/terasology/corerendering/rendering/dag/nodes/InitialPostProcessingNode.java
@@ -41,7 +41,7 @@ import static org.terasology.engine.rendering.opengl.ScalingFactors.FULL_SCALE;
  */
 public class InitialPostProcessingNode extends AbstractNode implements PropertyChangeListener {
     static final SimpleUri INITIAL_POST_FBO_URI = new SimpleUri("engine:fbo.initialPost");
-    private static final ResourceUrn INITIAL_POST_MATERIAL_URN = new ResourceUrn("engine:prog.initialPost");
+    private static final ResourceUrn INITIAL_POST_MATERIAL_URN = new ResourceUrn("CoreRendering:initialPost");
 
     private RenderingConfig renderingConfig;
     private WorldProvider worldProvider;

--- a/src/main/java/org/terasology/corerendering/rendering/dag/nodes/LateBlurNode.java
+++ b/src/main/java/org/terasology/corerendering/rendering/dag/nodes/LateBlurNode.java
@@ -1,18 +1,5 @@
-/*
- * Copyright 2017 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.corerendering.rendering.dag.nodes;
 
 import org.terasology.engine.config.Config;

--- a/src/main/java/org/terasology/corerendering/rendering/dag/nodes/LightShaftsNode.java
+++ b/src/main/java/org/terasology/corerendering/rendering/dag/nodes/LightShaftsNode.java
@@ -45,7 +45,7 @@ import static org.terasology.engine.rendering.opengl.ScalingFactors.HALF_SCALE;
  */
 public class LightShaftsNode extends ConditionDependentNode {
     public static final SimpleUri LIGHT_SHAFTS_FBO_URI = new SimpleUri("engine:fbo.lightShafts");
-    private static final ResourceUrn LIGHT_SHAFTS_MATERIAL_URN = new ResourceUrn("engine:prog.lightShafts");
+    private static final ResourceUrn LIGHT_SHAFTS_MATERIAL_URN = new ResourceUrn("CoreRendering:lightShafts");
 
     private BackdropProvider backdropProvider;
     private SubmersibleCamera activeCamera;

--- a/src/main/java/org/terasology/corerendering/rendering/dag/nodes/OpaqueBlocksNode.java
+++ b/src/main/java/org/terasology/corerendering/rendering/dag/nodes/OpaqueBlocksNode.java
@@ -44,7 +44,7 @@ import static org.terasology.engine.rendering.primitives.ChunkMesh.RenderPhase.O
  * In a typical world this is the majority of the world's landscape.
  */
 public class OpaqueBlocksNode extends AbstractNode implements WireframeCapable, PropertyChangeListener {
-    private static final ResourceUrn CHUNK_MATERIAL_URN = new ResourceUrn("engine:prog.chunk");
+    private static final ResourceUrn CHUNK_MATERIAL_URN = new ResourceUrn("CoreRendering:chunk");
 
     private WorldRenderer worldRenderer;
     private RenderQueuesHelper renderQueues;

--- a/src/main/java/org/terasology/corerendering/rendering/dag/nodes/OpaqueObjectsNode.java
+++ b/src/main/java/org/terasology/corerendering/rendering/dag/nodes/OpaqueObjectsNode.java
@@ -1,18 +1,5 @@
-/*
- * Copyright 2017 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.corerendering.rendering.dag.nodes;
 
 import org.terasology.engine.config.Config;

--- a/src/main/java/org/terasology/corerendering/rendering/dag/nodes/OutlineNode.java
+++ b/src/main/java/org/terasology/corerendering/rendering/dag/nodes/OutlineNode.java
@@ -37,7 +37,7 @@ import static org.terasology.engine.rendering.opengl.ScalingFactors.FULL_SCALE;
  */
 public class OutlineNode extends ConditionDependentNode {
     public static final SimpleUri OUTLINE_FBO_URI = new SimpleUri("engine:fbo.outline");
-    private static final ResourceUrn OUTLINE_MATERIAL_URN = new ResourceUrn("engine:prog.sobel");
+    private static final ResourceUrn OUTLINE_MATERIAL_URN = new ResourceUrn("CoreRendering:sobel");
 
     private RenderingConfig renderingConfig;
     private SubmersibleCamera activeCamera;

--- a/src/main/java/org/terasology/corerendering/rendering/dag/nodes/OutputToHMDNode.java
+++ b/src/main/java/org/terasology/corerendering/rendering/dag/nodes/OutputToHMDNode.java
@@ -30,7 +30,7 @@ import static org.terasology.engine.rendering.opengl.fbms.DisplayResolutionDepen
 public class OutputToHMDNode extends ConditionDependentNode {
     private static final SimpleUri LEFT_EYE_FBO_URI = new SimpleUri("engine:fbo.leftEye");
     private static final SimpleUri RIGHT_EYE_FBO_URI = new SimpleUri("engine:fbo.rightEye");
-    private static final ResourceUrn OUTPUT_TEXTURED_MATERIAL_URN = new ResourceUrn("engine:prog.outputPass");
+    private static final ResourceUrn OUTPUT_TEXTURED_MATERIAL_URN = new ResourceUrn("CoreRendering:outputPass");
     // TODO: make these configurable options
 
     private OpenVRProvider vrProvider;

--- a/src/main/java/org/terasology/corerendering/rendering/dag/nodes/OutputToScreenNode.java
+++ b/src/main/java/org/terasology/corerendering/rendering/dag/nodes/OutputToScreenNode.java
@@ -23,7 +23,7 @@ import static org.terasology.engine.rendering.world.WorldRenderer.RenderingStage
 import static org.terasology.engine.rendering.world.WorldRenderer.RenderingStage.MONO;
 
 public class OutputToScreenNode extends ConditionDependentNode {
-    private static final ResourceUrn OUTPUT_TEXTURED_MATERIAL_URN = new ResourceUrn("engine:prog.outputPass");
+    private static final ResourceUrn OUTPUT_TEXTURED_MATERIAL_URN = new ResourceUrn("CoreRendering:outputPass");
 
     private DisplayResolutionDependentFbo displayResolutionDependentFBOs;
     private DisplayDevice displayDevice;

--- a/src/main/java/org/terasology/corerendering/rendering/dag/nodes/PrePostCompositeNode.java
+++ b/src/main/java/org/terasology/corerendering/rendering/dag/nodes/PrePostCompositeNode.java
@@ -45,7 +45,7 @@ import static org.terasology.engine.rendering.dag.stateChanges.SetInputTextureFr
  * [1] And refractions? To be verified.
  */
 public class PrePostCompositeNode extends AbstractNode implements PropertyChangeListener {
-    private static final ResourceUrn PRE_POST_MATERIAL_URN = new ResourceUrn("engine:prog.prePostComposite");
+    private static final ResourceUrn PRE_POST_MATERIAL_URN = new ResourceUrn("CoreRendering:prePostComposite");
 
     private RenderingConfig renderingConfig;
     private WorldRenderer worldRenderer;

--- a/src/main/java/org/terasology/corerendering/rendering/dag/nodes/RefractiveReflectiveBlocksNode.java
+++ b/src/main/java/org/terasology/corerendering/rendering/dag/nodes/RefractiveReflectiveBlocksNode.java
@@ -82,7 +82,7 @@ public class RefractiveReflectiveBlocksNode extends AbstractNode implements Prop
     @Range(min = 0.0f, max = 5.0f)
     public static float waterOffsetY;
 
-    private static final ResourceUrn CHUNK_MATERIAL_URN = new ResourceUrn("engine:prog.chunk");
+    private static final ResourceUrn CHUNK_MATERIAL_URN = new ResourceUrn("CoreRendering:chunk");
 
     private RenderQueuesHelper renderQueues;
     private WorldRenderer worldRenderer;

--- a/src/main/java/org/terasology/corerendering/rendering/dag/nodes/ShadowMapNode.java
+++ b/src/main/java/org/terasology/corerendering/rendering/dag/nodes/ShadowMapNode.java
@@ -52,7 +52,7 @@ import static org.terasology.engine.rendering.primitives.ChunkMesh.RenderPhase.O
  */
 public class ShadowMapNode extends ConditionDependentNode implements PropertyChangeListener {
     public static final SimpleUri SHADOW_MAP_FBO_URI = new SimpleUri("engine:fbo.sceneShadowMap");
-    private static final ResourceUrn SHADOW_MAP_MATERIAL_URN = new ResourceUrn("engine:prog.shadowMap");
+    private static final ResourceUrn SHADOW_MAP_MATERIAL_URN = new ResourceUrn("CoreRendering:shadowMap");
     private static final int SHADOW_FRUSTUM_BOUNDS = 200;
     private Material shadowMapMaterial;
     private static final float STEP_SIZE = 50f;

--- a/src/main/java/org/terasology/corerendering/rendering/dag/nodes/SimpleBlendMaterialsNode.java
+++ b/src/main/java/org/terasology/corerendering/rendering/dag/nodes/SimpleBlendMaterialsNode.java
@@ -1,18 +1,5 @@
-/*
- * Copyright 2017 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.corerendering.rendering.dag.nodes;
 
 import org.terasology.engine.context.Context;

--- a/src/main/java/org/terasology/corerendering/rendering/dag/nodes/ToneMappingNode.java
+++ b/src/main/java/org/terasology/corerendering/rendering/dag/nodes/ToneMappingNode.java
@@ -35,7 +35,7 @@ import static org.terasology.engine.rendering.opengl.ScalingFactors.FULL_SCALE;
  */
 public class ToneMappingNode extends AbstractNode {
     public static final SimpleUri TONE_MAPPING_FBO_URI = new SimpleUri("engine:fbo.toneMapping");
-    private static final ResourceUrn TONE_MAPPING_MATERIAL_URN = new ResourceUrn("engine:prog.toneMapping");
+    private static final ResourceUrn TONE_MAPPING_MATERIAL_URN = new ResourceUrn("CoreRendering:toneMapping");
 
     private ScreenGrabber screenGrabber;
 

--- a/src/main/java/org/terasology/corerendering/rendering/dag/nodes/UpdateExposureNode.java
+++ b/src/main/java/org/terasology/corerendering/rendering/dag/nodes/UpdateExposureNode.java
@@ -1,18 +1,5 @@
-/*
- * Copyright 2017 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 package org.terasology.corerendering.rendering.dag.nodes;
 
 import org.lwjgl.opengl.GL11;

--- a/src/main/java/org/terasology/corerendering/rendering/dag/nodes/VignetteNode.java
+++ b/src/main/java/org/terasology/corerendering/rendering/dag/nodes/VignetteNode.java
@@ -42,7 +42,7 @@ import static org.terasology.engine.rendering.opengl.fbms.DisplayResolutionDepen
  * Requirements: https://github.com/MovingBlocks/Terasology/issues/3040
  */
 public class VignetteNode  extends AbstractNode implements PropertyChangeListener {
-    private static final ResourceUrn VIGNETTE_MATERIAL_URN = new ResourceUrn("engine:prog.vignette");
+    private static final ResourceUrn VIGNETTE_MATERIAL_URN = new ResourceUrn("CoreRendering:vignette");
 
     private RenderingConfig renderingConfig;
     private WorldProvider worldProvider;

--- a/src/main/java/org/terasology/corerendering/rendering/dag/nodes/WorldReflectionNode.java
+++ b/src/main/java/org/terasology/corerendering/rendering/dag/nodes/WorldReflectionNode.java
@@ -52,7 +52,7 @@ import static org.terasology.engine.rendering.primitives.ChunkMesh.RenderPhase.O
  * - https://docs.google.com/drawings/d/1Iz7MA8Y5q7yjxxcgZW-0antv5kgx6NYkvoInielbwGU/edit?usp=sharing
  */
 public class WorldReflectionNode extends ConditionDependentNode {
-    private static final ResourceUrn CHUNK_MATERIAL_URN = new ResourceUrn("engine:prog.chunk");
+    private static final ResourceUrn CHUNK_MATERIAL_URN = new ResourceUrn("CoreRendering:chunk");
 
     private RenderQueuesHelper renderQueues;
     private BackdropProvider backdropProvider;

--- a/src/main/java/org/terasology/corerendering/rendering/dag/nodes/package-info.java
+++ b/src/main/java/org/terasology/corerendering/rendering/dag/nodes/package-info.java
@@ -1,19 +1,5 @@
-/*
- * Copyright 2018 MovingBlocks
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *      http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-
+// Copyright 2021 The Terasology Foundation
+// SPDX-License-Identifier: Apache-2.0
 /**
  * This package contains the Renderer's nodes.
  *


### PR DESCRIPTION
this migrates in the shaders defined in engine. should make it easier to apply modifications to shaders since these don't need to be in sync with the engine anymore. 

PR: https://github.com/MovingBlocks/Terasology/pull/4765