### PR TITLE
feat: restore biome-based grass and foliage tinting

### DIFF
--- a/assets/shaders/chunk_frag.glsl
+++ b/assets/shaders/chunk_frag.glsl
@@ -65,6 +65,7 @@ uniform float clip;
 in float v_sunlight;
 in float v_blocklight;
 in float v_ambientLight;
+in vec4 v_colorOffset;
 
 //inverse is not available in GLSL 1.20, so calculate it manually
 mat2 inverse2(mat2 m) {
@@ -174,6 +175,23 @@ void main() {
             discard;
         }
     #endif
+
+    /* APPLY OVERALL BIOME COLOR OFFSET */
+    if (v_blockHint != BLOCK_HINT_GRASS) {
+        if (v_colorOffset.r < 0.99 && v_colorOffset.g < 0.99 && v_colorOffset.b < 0.99) {
+            if (color.g > 0.5) {
+                color.rgb = vec3(color.g) * v_colorOffset.rgb;
+            } else {
+                color.rgb *= v_colorOffset.rgb;
+            }
+        }
+        /* MASK GRASS AND APPLY BIOME COLOR */
+    } else {
+        vec4 maskColor = texture2D(textureEffects, vec2(10.0 * TEXTURE_OFFSET_EFFECTS + mod(texCoord.x, TEXTURE_OFFSET_EFFECTS), mod(texCoord.y, TEXTURE_OFFSET_EFFECTS)));
+
+        // Only use one channel so the color won't be altered
+        if (maskColor.a != 0.0) color.rgb = vec3(color.g) * v_colorOffset.rgb;
+    }
 #endif
 
     // Calculate daylight lighting value

--- a/assets/shaders/chunk_vert.glsl
+++ b/assets/shaders/chunk_vert.glsl
@@ -102,6 +102,7 @@ out float v_blocklight;
 out float v_ambientLight;
 flat out int isUpside;
 flat out int v_blockHint;
+out vec4 v_colorOffset;
 
 layout (location = 0) in vec3 in_vert;
 layout (location = 1) in vec3 in_normal;
@@ -114,6 +115,8 @@ layout (location = 5) in float in_sunlight;
 layout (location = 6) in float in_blocklight;
 layout (location = 7) in float in_ambientlight;
 
+layout (location = 8) in vec4 colorOffset;
+
 void main() {
 
     v_uv0 = in_uv0;
@@ -121,6 +124,7 @@ void main() {
     v_blocklight = in_blocklight;
     v_ambientLight = in_ambientlight;
     v_blockHint = in_flags;
+    v_colorOffset = colorOffset;
     vertexViewPos = modelViewMatrix * vec4(in_vert, 1.0);
     vertexWorldPos = in_vert + chunkPositionWorld.xyz;
 


### PR DESCRIPTION
This modifies the shaders to support https://github.com/MovingBlocks/Terasology/pull/4828. The shading logic is copied from https://github.com/MovingBlocks/Terasology/pull/3802.