### PR TITLE
Implement  FEATURE_ALPHA_REJECT

### DIFF
--- a/assets/shaders/chunk_vert.glsl
+++ b/assets/shaders/chunk_vert.glsl
@@ -186,9 +186,8 @@ void main() {
     gl_Position = vertexProjPos;
 
 #if defined (FEATURE_ALPHA_REJECT)
-    //TODO: find the right methods to determine which vertices have normals facing away from the viewpoint, and only alter those
-    //if (normal.x * vertexViewPos.x < 0 || normal.y * vertexViewPos.y < 0 || normal.z * vertexViewPos.z < 0) {
-        gl_Position.z -= 0.001;
-    //}
+	if (dot(normal, vec3(vertexViewPos)) > 0) {
+	   gl_Position.z -= 0.001;
+	}
 #endif
 }


### PR DESCRIPTION
In the current repo, the file chunk_vert.glsl mentions - TODO: find the right methods to determine which vertices have normals facing away from the viewpoint, and only alter those. Looks like this aims to fix z fighting. This PR implements this.