### PR TITLE
feat(sky): dim/brighten the moon highlight through its phase

### DIFF
--- a/assets/shaders/sky_frag.glsl
+++ b/assets/shaders/sky_frag.glsl
@@ -20,11 +20,14 @@ uniform vec4 skySettings;
 #define skyDaylightBrightness skySettings.z
 #define skyNightBrightness skySettings.w
 
+// 0.0 at new moon, 1.0 at full moon - see CelestialSystem#getMoonPhase(). Modulates the moon
+// highlight's peak brightness so the "moon" dims and brightens through its cycle (#94).
+uniform float moonPhaseIntensity = 1.0;
+
 const vec4 eyePos = vec4(0.0, 0.0, 0.0, 1.0);
 
 #define HIGHLIGHT_BLEND_START 0.1
 #define SUN_HIGHLIGHT_INTENSITY_FACTOR 1.0
-#define MOON_HIGHLIGHT_INTENSITY_FACTOR 1.0
 
 layout(location = 0) out vec4 outColor;
 
@@ -45,7 +48,7 @@ void main () {
 
     float moonHighlight = 0.0;
     if (negLDotV >= 0.0 && -l.y >= 0.0) {
-       moonHighlight = pow(negLDotV, moonExponent) * MOON_HIGHLIGHT_INTENSITY_FACTOR;
+       moonHighlight = pow(negLDotV, moonExponent) * moonPhaseIntensity;
     }
     if (-l.y < HIGHLIGHT_BLEND_START && -l.y >= 0.0) {
        moonHighlight *= 1.0 - (HIGHLIGHT_BLEND_START + l.y) / HIGHLIGHT_BLEND_START;

--- a/src/main/java/org/terasology/corerendering/rendering/dag/nodes/BackdropNode.java
+++ b/src/main/java/org/terasology/corerendering/rendering/dag/nodes/BackdropNode.java
@@ -166,6 +166,12 @@ public class BackdropNode extends AbstractNode implements WireframeCapable {
         skyMaterial.setFloat("colorExp", backdropProvider.getColorExp(), true);
         skyMaterial.setFloat4("skySettings", sunExponent, moonExponent, skyDaylightBrightness, skyNightBrightness, true);
 
+        // Moon phase in [0, 1): 0/1 is new moon, 0.5 is full moon. Fold it into a triangle wave so
+        // the highlight peaks at full moon and fades to nothing at new moon, rather than jumping. #94
+        float moonPhase = backdropProvider.getMoonPhase();
+        float moonPhaseIntensity = 1.0f - Math.abs(moonPhase * 2.0f - 1.0f);
+        skyMaterial.setFloat("moonPhaseIntensity", moonPhaseIntensity, true);
+
         Camera camera = worldRenderer.getActiveCamera();
         skyMaterial.setMatrix4("projectionMatrix", camera.getProjectionMatrix());
         skyMaterial.setMatrix4("modelViewMatrix", camera.getNormViewMatrix());


### PR DESCRIPTION
Companion to a MovingBlocks/Terasology engine PR adding `CelestialSystem`/`BackdropProvider#getMoonPhase()` for [MovingBlocks/Terasology#94](https://github.com/MovingBlocks/Terasology/issues/94) - a hook for basing the moon's phase on the game's day counter.

## What changed

`sky_frag.glsl`'s moon highlight (the soft glow rendered opposite the sun once it's below the horizon - there's no separate textured moon disc) previously used a hardcoded `MOON_HIGHLIGHT_INTENSITY_FACTOR` of `1.0`, so it was always full brightness regardless of what phase the moon should be in. Replaced that `#define` with a `moonPhaseIntensity` uniform, set in `BackdropNode` from `1.0 - abs(backdropProvider.getMoonPhase() * 2.0 - 1.0)` - a triangle wave that's `0` at new moon (phase 0 or 1) and `1` at full moon (phase 0.5), folding smoothly between. No new textures or art assets needed - this reuses the existing highlight rendering, just no longer holds its peak brightness constant.

## ⚠️ Please verify live before merging

Compiles against a local engine checkout carrying the paired `getMoonPhase()` addition. No GL context available here to render and confirm visually - the shader/uniform change is small and mirrors the existing `sunExponent`/`skySettings` wiring pattern already used a few lines above it in `BackdropNode`, but this genuinely needs an eyeball check in-game across a few in-game days to confirm the fade reads correctly (e.g. via the sun-halting debug command to fast-check specific phases).

Companion PR: MovingBlocks/Terasology#5387
